### PR TITLE
Upgrade to latest PBS.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,10 @@ jobs:
         uses: actions/checkout@v3
       - name: Check Formatting & Lints
         run: nox -e lint
+      - name: Configure Windows pytest short tmp dir path
+        if: matrix.os == 'windows-2022'
+        run: |
+          echo PYTEST_ADDOPTS="--basetemp C:\\tmp\\pytest" >> ${GITHUB_ENV}
       - name: Unit Tests
         run: nox -e test -- -vvs
       - name: Build & Package

--- a/lift.toml
+++ b/lift.toml
@@ -5,8 +5,8 @@ description = "Ship your interpreted executables using science."
 [[lift.interpreters]]
 id = "cpython"
 provider = "PythonBuildStandalone"
-release = "20230116"
-version = "3.11.1"
+release = "20230507"
+version = "3.11.3"
 lazy = true
 
 [[lift.files]]

--- a/noxfile.py
+++ b/noxfile.py
@@ -253,12 +253,7 @@ def create_zipapp(session: Session) -> Path:
 def test(session: Session) -> None:
     science_pyz = create_zipapp(session)
     test_env = {"BUILD_ROOT": str(BUILD_ROOT), "SCIENCE_TEST_PYZ_PATH": str(science_pyz)}
-
-    # TODO(John Sirois): Figure out why this fails for GH Windows 2022 runners and re-enable for
-    #  Windows: https://github.com/a-scie/lift/issues/9
-    xdist_args = [] if IS_WINDOWS else ["-n" "auto"]
-
-    session.run("pytest", *xdist_args, *(session.posargs or ["-v"]), env=test_env)
+    session.run("pytest", "-n" "auto", *(session.posargs or ["-v"]), env=test_env)
 
 
 @python_session()

--- a/tests/data/interpreter-groups.toml
+++ b/tests/data/interpreter-groups.toml
@@ -8,14 +8,12 @@ version = "0.11.0"
 [[lift.interpreters]]
 id = "cpython310"
 provider = "PythonBuildStandalone"
-release = "20230116"
 version = "3.10"
 lazy = true
 
 [[lift.interpreters]]
 id = "cpython311"
 provider = "PythonBuildStandalone"
-release = "20230116"
 version = "3.11"
 lazy = true
 

--- a/tests/test_exe.py
+++ b/tests/test_exe.py
@@ -7,6 +7,7 @@ import io
 import itertools
 import os
 import re
+import shutil
 import subprocess
 import sys
 from dataclasses import dataclass
@@ -159,7 +160,7 @@ def test_nested_filenames(
     dist_dir.mkdir()
 
     dest = dist_dir / science_pyz.name
-    os.link(science_pyz, dest)
+    shutil.copy(science_pyz, dest)
 
     with config.open(mode="r") as fp:
         config_data = toml.load(fp)


### PR DESCRIPTION
Remove test pinning so that we're always testing latest and bump science
from Python 3.11.1 to 3.11.3.

Fixes #9