### PR TITLE
Remove direct use of `os.environ`; leverage click.

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -285,4 +285,4 @@ def _package(session: Session, *extra_lift_args: str) -> None:
 @python_session()
 def package(session: Session) -> None:
     _package(session)
-    _package(session, "--invert-lazy", "cpython", "--name", "science-fat")
+    _package(session, "--invert-lazy", "cpython", "--app-name", "science-fat")

--- a/science/cache.py
+++ b/science/cache.py
@@ -5,15 +5,15 @@ from __future__ import annotations
 
 import atexit
 import hashlib
-import os
 from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Iterator, TypeAlias
 
-from appdirs import user_cache_dir
 from filelock import FileLock
+
+from science.context import ScienceConfig
 
 
 @dataclass(frozen=True)
@@ -80,7 +80,7 @@ class DownloadCache:
 
 
 def science_cache() -> Path:
-    return Path(os.environ.get("SCIENCE_CACHE", user_cache_dir("science")))
+    return ScienceConfig.active().cache_dir
 
 
 def download_cache() -> DownloadCache:

--- a/science/context.py
+++ b/science/context.py
@@ -1,0 +1,57 @@
+# Copyright 2023 Science project contributors.
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TypeVar
+
+import click
+from appdirs import user_cache_dir
+
+
+class ContextConfig:
+    pass
+
+
+_T = TypeVar("_T", bound=ContextConfig)
+
+
+def active_context_config(config_type: type[_T]) -> _T | None:
+    current_context = click.get_current_context(silent=True)
+    return current_context.find_object(config_type) if current_context else None
+
+
+@dataclass(frozen=True)
+class ScienceConfig(ContextConfig):
+    DEFAULT_CACHE_DIR = Path(user_cache_dir("science"))
+
+    @classmethod
+    def active(cls) -> ScienceConfig:
+        return active_context_config(cls) or ScienceConfig()
+
+    verbosity: int = 0
+    cache_dir: Path = DEFAULT_CACHE_DIR
+
+    @property
+    def quiet(self) -> bool:
+        return self.verbosity < 0
+
+    @property
+    def verbose(self) -> bool:
+        return self.verbosity > 0
+
+    def configure_logging(self, root_logger: logging.Logger):
+        match self.verbosity:
+            case v if v <= -2:
+                root_logger.setLevel(logging.FATAL)
+            case -1:
+                root_logger.setLevel(logging.ERROR)
+            case 0:
+                root_logger.setLevel(logging.WARNING)
+            case 1:
+                root_logger.setLevel(logging.INFO)
+            case v if v >= 2:
+                root_logger.setLevel(logging.DEBUG)

--- a/tests/test_exe.py
+++ b/tests/test_exe.py
@@ -332,7 +332,7 @@ def test_url_source_bad_size(tmp_path: Path, science_exe: Path) -> None:
         science_exe,
         lazy=False,
         expected_size=bad_size,
-        SCIENCE_CACHE=str(tmp_path / "cache"),
+        SCIENCE_CACHE_DIR=str(tmp_path / "cache"),
     )
     result.assert_failure()
     assert re.search(
@@ -349,7 +349,7 @@ def test_url_source_bad_fingerprint(tmp_path: Path, science_exe: Path) -> None:
         science_exe,
         lazy=False,
         expected_fingerprint=bad_fingerprint,
-        SCIENCE_CACHE=str(tmp_path / "cache"),
+        SCIENCE_CACHE_DIR=str(tmp_path / "cache"),
     )
     result.assert_failure()
     assert re.search(
@@ -598,7 +598,7 @@ def test_invert_lazy(tmp_path: Path, science_exe: Path) -> None:
         tmp_path,
         science_exe,
         lazy=True,
-        extra_lift_args=["--name", "skinny"],
+        extra_lift_args=["--app-name", "skinny"],
         expected_name="skinny",
     )
     result.assert_success()
@@ -606,7 +606,11 @@ def test_invert_lazy(tmp_path: Path, science_exe: Path) -> None:
     skinny_scie = result.scie
 
     result = create_url_source_scie(
-        tmp_path, science_exe, lazy=False, extra_lift_args=["--name", "fat"], expected_name="fat"
+        tmp_path,
+        science_exe,
+        lazy=False,
+        extra_lift_args=["--app-name", "fat"],
+        expected_name="fat",
     )
     result.assert_success()
     assert result.scie.name == Platform.current().binary_name("fat")
@@ -619,7 +623,7 @@ def test_invert_lazy(tmp_path: Path, science_exe: Path) -> None:
         tmp_path / "via-inversion",
         science_exe,
         lazy=True,
-        extra_lift_args=["--invert-lazy", "LICENSE", "--name", "fat"],
+        extra_lift_args=["--invert-lazy", "LICENSE", "--app-name", "fat"],
         expected_name="fat",
     )
     result.assert_success()


### PR DESCRIPTION
This completes cleaning up configuration by using a few more click
`Context` features.