### PR TITLE
Fix ptex file order and science url in build info.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,13 @@
 # Release Notes
 
+## 0.1.2
+
+This release brings two fixes prompted by [scie-pants](https://github.com/pantsbuild/scie-pants)
+adoption of `science`:
++ Fix science binary url in build info when using `--include-provenance`.
++ Fix the generated JSON lift manifest to position the ptex file 1st instead of last so that the
+  last file specified by the user can take the spot of the zip trailer.
+
 ## 0.1.1
 
 Fix provenance (`science lift --include-provenance ...`) to include the correct download URL for

--- a/noxfile.py
+++ b/noxfile.py
@@ -274,11 +274,14 @@ def _package(session: Session, *extra_lift_args: str) -> None:
         "--include-provenance",
         *extra_lift_args,
         "build",
-        "--dest-dir",
-        str(DIST_DIR),
         "--hash",
         "sha256",
         "--use-platform-suffix",
+        env={
+            "SCIENCE_LIFT_BUILD_DEST_DIR": os.environ.get(
+                "SCIENCE_LIFT_BUILD_DEST_DIR", str(DIST_DIR)
+            )
+        },
     )
 
 

--- a/science/__init__.py
+++ b/science/__init__.py
@@ -1,4 +1,4 @@
 # Copyright 2022 Science project contributors.
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-__version__ = "0.1.1"
+__version__ = "0.1.2"

--- a/science/build_info.py
+++ b/science/build_info.py
@@ -61,12 +61,12 @@ class BuildInfo:
     git_state: str | None = None
     app_info: FrozenDict[str, Any] = FrozenDict()
 
-    def to_dict(self, app_name: str = "science", **extra_app_info: Any) -> dict[str, Any]:
+    def to_dict(self, **extra_app_info: Any) -> dict[str, Any]:
         binary = dict[str, Any](
             version=__version__,
             url=(
                 f"https://github.com/a-scie/lift/releases/download/v{__version__}/"
-                f"{Platform.current().qualified_binary_name(app_name)}"
+                f"{Platform.current().qualified_binary_name('science')}"
             ),
         )
         if self.digest:

--- a/science/exe.py
+++ b/science/exe.py
@@ -14,6 +14,7 @@ import subprocess
 import sys
 import tempfile
 import traceback
+from collections import deque
 from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
@@ -142,10 +143,10 @@ def _export(
         chroot = dest_dir / platform.value
         chroot.mkdir(parents=True, exist_ok=True)
 
-        bindings: list[Command] = []
-        distributions: list[Distribution] = []
+        bindings = list[Command]()
+        distributions = list[Distribution]()
 
-        requested_files: list[File] = []
+        requested_files = deque[File]()
         file_paths_by_id = {
             file_mapping.id: file_mapping.path.resolve()
             for file_mapping in lift_config.file_mappings
@@ -181,7 +182,7 @@ def _export(
         if any(isinstance(file.source, Fetch) and file.source.lazy for file in requested_files):
             ptex = a_scie.ptex(chroot, specification=application.ptex, platform=platform)
             file_paths_by_id[ptex.id] = chroot / ptex.name
-            requested_files.append(ptex)
+            requested_files.appendleft(ptex)
             argv1 = (
                 application.ptex.argv1
                 if application.ptex and application.ptex.argv1

--- a/science/lift.py
+++ b/science/lift.py
@@ -113,7 +113,7 @@ def emit_manifest(
     }
     data = dict[str, Any](scie=scie_data)
     if build_info:
-        data.update(science=build_info.to_dict(app_name=name, **(app_info or {})))
+        data.update(science=build_info.to_dict(**(app_info or {})))
     if fetch_urls:
         data.update(ptex=fetch_urls)
 


### PR DESCRIPTION
In the process of switching `scie-pants` over from raw scie-jump use to
science two bugs were discovered:
+ The build info science url basename prefix took on the name of the
  user app instead of science.
+ When the ptex binary was included, it was added in the last position
  in the file list ensuring a scie-tote was always needed instead of
  honoring the user file list last entry which might be a valid zip
  trailer.

Additionally, to allow `scie-pants` to override the packaging directory
when using a custom version of science, switch from `--dest-dir` to the
env var equivalent when not already set.