### PR TITLE
Add `science doc open`.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,4 @@ jobs:
       - name: Build & Package
         run: nox -e package
       - name: Generate Doc Site
-        # We use a fork of https://github.com/vsalvino/sphinx-library currently which necessitates
-        # a VCS requirement and that nets a non-universal lock item; so we skip for now.
-        if: matrix.os != 'windows-2022'
         run: nox -e doc linkcheck

--- a/lift.toml
+++ b/lift.toml
@@ -14,6 +14,11 @@ version = "3.11.3"
 lazy = true
 
 [[lift.files]]
+# This is pointed at the output of the sphinx htm doc gen to produce a zip of the static html site
+# using `science lift --file docsite=docs/build/html ...`.
+name = "docsite"
+
+[[lift.files]]
 # The nox build emits this at `dist/science.pyz` and so our packaging process maps that path using
 # `science lift --file science.pyz=dist/science.pyz ...`.
 name = "science.pyz"
@@ -33,4 +38,6 @@ args = [
 remove_re = [
     "SHIV_.*",
 ]
-replace = { SHIV_ROOT = "{scie.bindings}/shiv_root" }
+[lift.commands.env.replace]
+SHIV_ROOT = "{scie.bindings}/shiv_root"
+SCIENCE_DOC_LOCAL = "{docsite}/index.html"

--- a/nox-support/doc-reqs.windows-amd64.lock.txt
+++ b/nox-support/doc-reqs.windows-amd64.lock.txt
@@ -10,8 +10,16 @@ sphinx==6.2.1 \
 sphinx-click==4.4.0 \
   --hash=sha256:2821c10a68fc9ee6ce7c92fad26540d8d8c8f45e6d7258f0e4fb7529ae8fab49 \
   --hash=sha256:cc67692bd28f482c7f01531c61b64e9d2f069bfcf3d24cbbb51d4a84a749fa48
+
+# N.B.: The 21c3f448d17224246e36a5db678e98b9261a1909604c160cd12f45fa1e7eb695 hash
+# was added manually. This is the hash of the 1.1.2 wheel which does not match the
+# VCS requirement this was locked from. The end result is docgen works on Windows
+# until https://github.com/vsalvino/sphinx-library/pull/3 is released and we can
+# switch back to the PyPI release.
 sphinx-library==1.1.2 \
-  --hash=sha256:f6bb070fbc9a42482197dfdfa29c01e9e245822a86f17541f5a6dcee098cfe1a
+  --hash=sha256:f6bb070fbc9a42482197dfdfa29c01e9e245822a86f17541f5a6dcee098cfe1a \
+  --hash=sha256:21c3f448d17224246e36a5db678e98b9261a1909604c160cd12f45fa1e7eb695
+
 jinja2==3.1.2 \
   --hash=sha256:6088930bfe239f0e6710546ab9c19c9ef35e29792895fed6e6e31a023a182a61 \
   --hash=sha256:31351a702a408a9e7595a8fc6150fc3f43bb6bf7e319770cbc0db9df9437e852

--- a/science/context.py
+++ b/science/context.py
@@ -55,3 +55,9 @@ class ScienceConfig(ContextConfig):
                 root_logger.setLevel(logging.INFO)
             case v if v >= 2:
                 root_logger.setLevel(logging.DEBUG)
+
+
+@dataclass(frozen=True)
+class DocConfig(ContextConfig):
+    site: str
+    local: Path | None = None

--- a/science/model.py
+++ b/science/model.py
@@ -115,8 +115,13 @@ class File:
     def __post_init__(self) -> None:
         if self.source and not self.digest:
             raise InputError(
-                f"Since {self} has a {self.source.source_type} source it must also specify `size` "
-                f"and `fingerprint`."
+                f"File {self.id!r} has a {self.source.source_type} source it must also specify "
+                "`size` and `fingerprint`."
+            )
+        if self.digest and self.type is FileType.Directory:
+            raise InputError(
+                f"File {self.id!r} is a directory and has a digest defined but digests are not "
+                "supported for directories."
             )
 
     @property


### PR DESCRIPTION
By default this opens a local docsite appropriate to the version of
`science` currently running. Specifying `--remote` will open the
official doc site instead.

Closes #31