### PR TITLE
Expand lift manifest docs.

### DIFF
--- a/science/build_info.py
+++ b/science/build_info.py
@@ -15,6 +15,7 @@ from typing import Any
 
 from science import __version__
 from science.dataclass.reflect import metadata
+from science.doc import DOC_SITE_URL
 from science.frozendict import FrozenDict
 from science.hashing import Digest, Provenance
 from science.platform import Platform
@@ -76,9 +77,9 @@ class BuildInfo:
 
         build_info = dict[str, Any](
             notes=[
-                "This scie lift JSON manifest was generated from a source lift toml manifest "
-                "using the science binary.",
-                f"Find out more here: https://github.com/a-scie/lift/blob/v{__version__}/README.md",
+                f"This scie lift JSON manifest was generated from {self.lift_toml.source} using "
+                "the science binary.",
+                f"Find out more here: {DOC_SITE_URL}",
             ],
             binary=binary,
             manifest=lift_toml,

--- a/science/dataclass/reflect.py
+++ b/science/dataclass/reflect.py
@@ -5,11 +5,9 @@ from __future__ import annotations
 
 import dataclasses
 import inspect
-import os
 import typing
 from dataclasses import MISSING, dataclass
 from functools import cache, cached_property
-from importlib.metadata import EntryPoint
 from typing import (
     Any,
     Callable,
@@ -23,7 +21,7 @@ from typing import (
 )
 
 from science.dataclass import Dataclass, document_dataclass, get_documentation
-from science.types import TypeInfo, fully_qualified_name
+from science.types import TypeInfo
 
 _FIELD_METADATA_KEY = f"{__name__}.field_metadata"
 
@@ -32,25 +30,34 @@ _FIELD_METADATA_KEY = f"{__name__}.field_metadata"
 class FieldMetadata:
     DEFAULT: ClassVar[FieldMetadata]
 
-    _doc: str | None = None
+    doc_func: Callable[[], str] | None = None
     reference: bool = False
     inline: bool = False
     hidden: bool = False
 
     @cached_property
-    def doc(self) -> str | None:
-        return inspect.cleandoc(self._doc) if self._doc else None
+    def doc(self) -> str:
+        return inspect.cleandoc(self.doc_func()) if self.doc_func else ""
 
 
 FieldMetadata.DEFAULT = FieldMetadata()
 
 
 def metadata(
-    doc: str | None = None, *, reference: bool = False, inline: bool = False, hidden: bool = False
+    doc: str | Callable[[], str] = "",
+    *,
+    reference: bool = False,
+    inline: bool = False,
+    hidden: bool = False,
 ) -> Mapping[str, FieldMetadata]:
+    if isinstance(doc, str):
+        doc_func = lambda: doc
+    else:
+        doc_func = doc
+
     return {
         _FIELD_METADATA_KEY: FieldMetadata(
-            _doc=doc, reference=reference, inline=inline, hidden=hidden
+            doc_func=doc_func, reference=reference, inline=inline, hidden=hidden
         )
     }
 
@@ -60,6 +67,11 @@ class ClassMetadata:
     DEFAULT: ClassVar[ClassMetadata]
 
     alias: str | None = None
+    doc_func: Callable[[], str] | None = None
+
+    @cached_property
+    def doc(self) -> str:
+        return inspect.cleandoc(self.doc_func()) if self.doc_func else ""
 
 
 ClassMetadata.DEFAULT = ClassMetadata()
@@ -70,7 +82,7 @@ _T = TypeVar("_T")
 
 @dataclass_transform()
 def documented_dataclass(
-    doc: str = "",
+    doc: str | Callable[[], str] = "",
     *,
     alias: str | None = None,
     init: bool = True,
@@ -100,30 +112,26 @@ def documented_dataclass(
                 weakref_slot=weakref_slot,
             )(cls),
         )
-        if doc:
-            data_type.__doc__ = doc
-        return document_dataclass(data_type, ClassMetadata(alias=alias))
+
+        if not doc:
+
+            def doc_func() -> str:
+                if doc_ := inspect.getdoc(data_type):
+                    # Unfortunately, @dataclass automatically generates __doc__ with no way to turn
+                    # it off. The generated doc, though, is very nearly == inspect.signature of the
+                    # @dataclass type.
+                    if f"{doc_} -> None" != f"{data_type.__name__}{inspect.signature(data_type)}":
+                        return inspect.cleandoc(doc_)
+                return ""
+
+        elif isinstance(doc, str):
+            doc_func = lambda: cast(str, doc)
+        else:
+            doc_func = doc
+
+        return document_dataclass(data_type, ClassMetadata(alias=alias, doc_func=doc_func))
 
     return wrapper
-
-
-_D = TypeVar("_D", bound=Dataclass)
-
-
-@dataclass(frozen=True)
-class Ref(Generic[_D]):
-    @classmethod
-    @cache
-    def _create_slug(cls) -> Callable[[type], str]:
-        slugifier = os.environ.get("_SCIENCE_REF_SLUGIFIER")
-        if slugifier:
-            return EntryPoint(name="", group="", value=slugifier).load()
-        return fully_qualified_name
-
-    type_: type[_D]
-
-    def __str__(self) -> str:
-        return self._create_slug()(self.type_)
 
 
 _F = TypeVar("_F")
@@ -134,7 +142,7 @@ class FieldInfo(Generic[_F]):
     name: str
     type: TypeInfo[_F]
     default: Any
-    doc: str | None
+    doc: str
     reference: bool
     inline: bool = False
     hidden: bool = False
@@ -144,24 +152,19 @@ class FieldInfo(Generic[_F]):
         return self.default is not MISSING
 
 
+_D = TypeVar("_D", bound=Dataclass)
+
+
 @dataclass(frozen=True)
 class DataclassInfo(Generic[_D]):
     type: type[_D]
     alias: str | None
+    doc: str
     field_info: tuple[FieldInfo, ...] = ()
 
     @property
     def name(self) -> str:
         return self.alias or self.type.__name__
-
-    @cached_property
-    def doc(self) -> str | None:
-        if doc := inspect.getdoc(self.type):
-            # Unfortunately, @dataclass automatically generates __doc__ with no way to turn it off.
-            # The generated doc, though, is very nearly == inspect.signature of the @dataclass type.
-            if f"{doc} -> None" != f"{self.type.__name__}{inspect.signature(self.type)}":
-                return inspect.cleandoc(doc).strip()
-        return None
 
 
 @cache
@@ -183,7 +186,10 @@ def dataclass_info(data_type: type[_D]) -> DataclassInfo[_D]:
             )
 
     return DataclassInfo(
-        type=data_type, alias=class_metadata.alias, field_info=tuple(iter_field_info())
+        type=data_type,
+        alias=class_metadata.alias,
+        doc=class_metadata.doc,
+        field_info=tuple(iter_field_info()),
     )
 
 

--- a/science/doc.py
+++ b/science/doc.py
@@ -1,0 +1,34 @@
+# Copyright 2023 Science project contributors.
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from functools import cache
+from importlib.metadata import EntryPoint
+from typing import Callable, Generic, TypeVar
+
+from science.dataclass import Dataclass
+from science.types import fully_qualified_name
+
+DOC_SITE_URL = "https://science.scie.app"
+
+
+_D = TypeVar("_D", bound=Dataclass)
+
+
+@dataclass(frozen=True)
+class Ref(Generic[_D]):
+    @classmethod
+    @cache
+    def _create_slug(cls) -> Callable[[type], str]:
+        # This is an affordance for the Sphinx doc-site generation and is set up in `docs/conf.py`.
+        if slugifier := os.environ.get("_SCIENCE_REF_SLUGIFIER"):
+            return EntryPoint(name="", group="", value=slugifier).load()
+        return fully_qualified_name
+
+    type_: type[_D]
+
+    def __str__(self) -> str:
+        return self._create_slug()(self.type_)

--- a/science/model.py
+++ b/science/model.py
@@ -338,9 +338,9 @@ class Interpreter(Dataclass):
         metadata=metadata(
             lambda: f"""An identifier to use in `#{{<id>...}}` placeholders.
 
-            The `#{{<id>}}` placeholder can be used a a placeholder [`command`](#{Ref(Command)})
-            fields to reference the interpreter distribution archive or `#{{<id>:<name>}}` to
-            reference named files provided by the interpreter distribution.
+            The `#{{<id>}}` placeholder can be used in [`command`](#{Ref(Command)}) fields to
+            reference the interpreter distribution archive. The `#{{<id>:<name>}}` placeholder can
+            be used to reference named files provided by the interpreter distribution.
             """
         )
     )

--- a/science/model.py
+++ b/science/model.py
@@ -28,7 +28,8 @@ from packaging.version import Version
 
 from science.build_info import BuildInfo
 from science.dataclass import Dataclass
-from science.dataclass.reflect import Ref, documented_dataclass, metadata
+from science.dataclass.reflect import documented_dataclass, metadata
+from science.doc import Ref
 from science.errors import InputError
 from science.frozendict import FrozenDict
 from science.hashing import Digest, ExpectedDigest
@@ -102,15 +103,106 @@ class Fetch:
 FileSource: TypeAlias = Fetch | Binding | None
 
 
-@documented_dataclass(frozen=True, alias="file")
+@documented_dataclass(
+    f"""A file to include in the scie.
+
+    Files are generally embedded in the scie executable and extracted as needed at run-time using
+    a concurrency-safe file system cache. Archives are unpacked unless the file type is marked
+    `{FileType.Blob.value!r}`
+    """,
+    frozen=True,
+    alias="file",
+)
 class File:
-    name: str
-    key: str | None = None
-    digest: Digest | None = None
-    type: FileType | None = None
-    is_executable: bool = False
-    eager_extract: bool = False
-    source: FileSource = None
+    name: str = dataclasses.field(
+        metadata=metadata(
+            f"""\
+            The name of the file.
+
+            This will usually be the actual file name or the relative path to a file, but it can
+            also be an abstract name. If the file name is not a relative path there are two things
+            to note:
+            * If the file `type` is not explicitly set, it will be inferred from the extension
+              unless the file resolves as a directory, in which case it will have type
+              `{FileType.Directory.value!r}`.
+            * The file will need to be mapped via the `science lift --file <name>=<path> ...` option
+              at build-time.
+            """
+        )
+    )
+    key: str | None = dataclasses.field(
+        default=None,
+        metadata=metadata(
+            lambda: f"""\
+            An alternate name for the file.
+
+            The key can be used in place of the `name` in `{{<name>}}` or `{{scie.file.<name>}}`
+            placeholders in [`command`](#{Ref(Command)}) fields or when mapping the the file using
+            the `science lift --file <name>=<path> ...` option at build-time.
+            """
+        ),
+    )
+    digest: Digest | None = dataclasses.field(
+        default=None,
+        metadata=metadata(
+            f"""The expected digest of the file.
+
+            The digest will be checked at scie build-time if the file has no `source` and it will be
+            checked again upon extraction from the scie at runtime.
+            """
+        ),
+    )
+    type: FileType | None = dataclasses.field(
+        default=None,
+        metadata=metadata(
+            f"""The file type expected.
+
+            ```{{note}}
+            Can be set to `{FileType.Blob.value!r}` to turn off automatic extraction of recognised
+            archive types.
+            ```
+            """
+        ),
+    )
+    is_executable: bool = dataclasses.field(
+        default=False,
+        metadata=metadata(
+            """Is the file an executable.
+
+            This is auto-detected if the file has no `source` but must be set if the file is an
+            executable that is provided by a `source`. This has no effect for Windows platform
+            scies.
+            """
+        ),
+    )
+    eager_extract: bool = dataclasses.field(
+        default=False,
+        metadata=metadata(
+            lambda: f"""Extract the file from the scie upon first execution of the scie.
+
+            Although files are automatically extracted when referenced directly or indirectly by
+            placeholders in the scie [`command`](#{Ref(Command)}) selected for execution, the scie
+            may have other un-referenced files used by other commands that you wish to be extracted
+            eagerly anyhow.
+            """
+        ),
+    )
+    source: FileSource = dataclasses.field(
+        default=None,
+        metadata=metadata(
+            lambda: f"""A source for the file's byte content.
+
+            Normally files are expected to be found locally at scie build-time, but you may want
+            science to fetch them for you as a convenience at build time or you may want the scie
+            to fetch them lazily at run-time. Specifying a [`source`](#{Ref(Fetch)}) table can
+            accomplish either.
+
+            For more exotic cases the source can be a string that is the name of a binding
+            [`command`](#{Ref(Command)}) that accepts the `name` of the file as its sole argument
+            and produces the file's byte content on stdout.
+            """
+        ),
+    )
 
     def __post_init__(self) -> None:
         if self.source and not self.digest:
@@ -227,9 +319,31 @@ class Provider(Protocol[ConfigDataclass]):
         ...
 
 
-@documented_dataclass(frozen=True, alias="interpreter")
+@documented_dataclass(
+    f"""An interpreter distribution.
+
+    For example, a CPython distribution from [Python Standalone Builds][PBS] or a JDK archive.
+
+    These are supplied by [Providers](#built-in-providers) and produce a [`file`](#{Ref(File)})
+    entry in the scie with special `#{{<id>:<name>}}` placeholder support for accessing named files
+    within the distribution archive.
+
+    [PBS]: https://python-build-standalone.readthedocs.io
+    """,
+    frozen=True,
+    alias="interpreter",
+)
 class Interpreter(Dataclass):
-    id: Identifier
+    id: Identifier = dataclasses.field(
+        metadata=metadata(
+            lambda: f"""An identifier to use in `#{{<id>...}}` placeholders.
+
+            The `#{{<id>}}` placeholder can be used a a placeholder [`command`](#{Ref(Command)})
+            fields to reference the interpreter distribution archive or `#{{<id>:<name>}}` to
+            reference named files provided by the interpreter distribution.
+            """
+        )
+    )
     provider: Provider = dataclasses.field(
         metadata=metadata(
             """The name of a Science Provider implementation.
@@ -241,9 +355,40 @@ class Interpreter(Dataclass):
             reference=True,
         )
     )
+    lazy: bool = dataclasses.field(
+        default=False,
+        metadata=metadata(
+            f"""Whether to lazily fetch the interpreter distribution at scie run-time.
+
+            By default, the interpreter distribution is fetched and embedded in the scie at
+            build-time.
+
+            ```{{note}}
+            Science uses [`ptex`](https://github.com/a-scie/ptex) to perform lazy run-time fetching
+            and will embed it as a [`file`](#{Ref(File)}) in the scie. You can control the version
+            used and other aspects of the fetch with the [`ptex` table](#{Ref(Ptex)}).
+            ```
+            """,
+        ),
+    )
 
 
-@documented_dataclass(frozen=True, alias="interpreter_group")
+@documented_dataclass(
+    f"""A group of [`interpreters`][1] from the same provider that can be dynamically selected from.
+
+    An interpreter group is useful if you want to ship a single scie binary that can dynamically
+    select an appropriate interpreter at runtime.
+
+    ```{{tip}}
+    To cut down on assembled scie size, it generally makes sense to mark all or all but one
+    interpreter distribution in the group as `lazy = true`.
+    ```
+
+    [1]: #{Ref(Interpreter)}
+    """,
+    frozen=True,
+    alias="interpreter_group",
+)
 class InterpreterGroup:
     @classmethod
     def create(cls, id_: Identifier, selector: str, interpreters: Iterable[Interpreter]):
@@ -268,11 +413,27 @@ class InterpreterGroup:
             )
         return cls(id=id_, selector=selector, members=members)
 
-    id: Identifier
-    selector: str
+    id: Identifier = dataclasses.field(
+        metadata=metadata(
+            f"""An identifier to use in `#{{<id>...}}` placeholders.
+
+            These work just like [`interpreter`](#{Ref(Interpreter)}) ids, proxying through to the
+            interpreter group member selected by the `selector`.
+            """
+        )
+    )
+    selector: str = dataclasses.field(
+        metadata=metadata(
+            f"""A string, that should resolve to the `id` of a member of the group.
+
+            The selector is resolved in the same manner as [`command`](#{Ref(Command)}) fields where
+            any placeholders are recursively resolved.
+            """
+        )
+    )
     members: frozenset[Interpreter] = dataclasses.field(
         metadata=metadata(
-            f"""The `id`s of the [interpreter](#{Ref(Interpreter)})s that are members of this group.
+            f"""The ids of the [`interpreter`](#{Ref(Interpreter)})s that are members of this group.
 
             There must be at lease two unique ids provided to form a group.
             """,


### PR DESCRIPTION
In order to forward reference some types declared lower in the same
file, the doc strings needed to be lazier; so both field and class doc
metadata can now be supplied by a function.