### PR TITLE
Update internal PBS to 20230726 3.11.4.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## 0.1.3
+
+Update the science internal Python distribution to [PBS](
+https://github.com/indygreg/python-build-standalone/) CPython 3.11.4. This should make `science`
+executable out of the box on more Linux distros.
+
 ## 0.1.2
 
 This release brings two fixes prompted by [scie-pants](https://github.com/pantsbuild/scie-pants)

--- a/lift.toml
+++ b/lift.toml
@@ -7,8 +7,8 @@ description = "Ship your interpreted executables using science."
 [[lift.interpreters]]
 id = "cpython"
 provider = "PythonBuildStandalone"
-release = "20230507"
-version = "3.11.3"
+release = "20230726"
+version = "3.11.4"
 # By default science ships as a "thin" scie that fetches CPython 3.11 on first run.
 # We use `science lift --invert-lazy cpython ...` when producing "fat" scies.
 lazy = true

--- a/science/__init__.py
+++ b/science/__init__.py
@@ -3,6 +3,6 @@
 
 from packaging.version import Version
 
-__version__ = "0.1.2"
+__version__ = "0.1.3"
 
 VERSION = Version(__version__)


### PR DESCRIPTION
This removes a dependence on the problematic `libcrypt.so.1` on Linux
and should allow `science` to run out of the box on more Linux distros.

See:
+ https://github.com/indygreg/python-build-standalone/issues/173
+ https://github.com/indygreg/python-build-standalone/releases/tag/20230726