### PR TITLE
Add command descriptions to JSON lift manifest.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## 0.2.1
+
+Fix command descriptions not being rendered in the JSON lift manifest of built scies.
+
 ## 0.2.0
 
 Add support for specifying a custom base `nce` cache dir and upgrade the internal [PBS](

--- a/science/__init__.py
+++ b/science/__init__.py
@@ -3,6 +3,6 @@
 
 from packaging.version import Version
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 
 VERSION = Version(__version__)

--- a/science/commands/lift.py
+++ b/science/commands/lift.py
@@ -280,6 +280,9 @@ def _render_command(
     if env:
         cmd["env"] = env
 
+    if description := command.description:
+        cmd["description"] = description
+
     return command.name or "", cmd
 
 

--- a/tests/data/command-descriptions.toml
+++ b/tests/data/command-descriptions.toml
@@ -18,7 +18,7 @@ import json
 import sys
 
 
-with open("{scie.lift}") as fp:
+with open(r"{scie.lift}") as fp:
     data = json.load(fp)
 
 def get_description(command_name: str) -> str | None:

--- a/tests/data/command-descriptions.toml
+++ b/tests/data/command-descriptions.toml
@@ -1,0 +1,36 @@
+[lift]
+name = "command-descriptions"
+description = "Test command decription propagation."
+
+[[lift.interpreters]]
+id = "cpython"
+provider = "PythonBuildStandalone"
+version = "3.10"
+lazy = true
+
+[[lift.commands]]
+description = "Print a JSON object of command descriptions by name."
+exe = "#{cpython:python}"
+args = [
+    "-c",
+    """
+import json
+import sys
+
+
+with open("{scie.lift}") as fp:
+    data = json.load(fp)
+
+def get_description(command_name: str) -> str | None:
+    return data["scie"]["lift"]["boot"]["commands"][command_name].get("description")
+
+json.dump(
+    {{command_name: get_description(command_name) for command_name in ("", "version")}, sys.stdout
+)
+    """
+]
+
+[[lift.commands]]
+name = "version"
+exe = "#{cpython:python}"
+args = ["-V"]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -141,19 +141,12 @@ def test_command_descriptions(tmp_path: Path, science_pyz: Path) -> None:
 
         exe_path = tmp_path / Platform.current().binary_name("command-descriptions")
         scie_base = tmp_path / "scie-base"
-        result = subprocess.run(
-            args=[exe_path],
-            env={**os.environ, "SCIE_BASE": str(scie_base)},
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-            # check=True,
+        data = json.loads(
+            subprocess.run(
+                args=[exe_path],
+                env={**os.environ, "SCIE_BASE": str(scie_base)},
+                stdout=subprocess.PIPE,
+                check=True,
+            ).stdout
         )
-        if result.returncode != 0:
-            print(f">>> The scie exited with {result.returncode}", file=sys.stderr)
-            print(f"STDOUT:\n{result.stdout}", file=sys.stderr)
-            print(f"STDERR:\n{result.stderr}", file=sys.stderr)
-        result.check_returncode()
-
-        data = json.loads(result.stdout)
         assert {"": "Print a JSON object of command descriptions by name.", "version": None} == data

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -141,12 +141,19 @@ def test_command_descriptions(tmp_path: Path, science_pyz: Path) -> None:
 
         exe_path = tmp_path / Platform.current().binary_name("command-descriptions")
         scie_base = tmp_path / "scie-base"
-        data = json.loads(
-            subprocess.run(
-                args=[exe_path],
-                env={**os.environ, "PYTHON": "cpython310", "SCIE_BASE": str(scie_base)},
-                stdout=subprocess.PIPE,
-                check=True,
-            ).stdout
+        result = subprocess.run(
+            args=[exe_path],
+            env={**os.environ, "SCIE_BASE": str(scie_base)},
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            # check=True,
         )
+        if result.returncode != 0:
+            print(f">>> The scie exited with {result.returncode}", file=sys.stderr)
+            print(f"STDOUT:\n{result.stdout}", file=sys.stderr)
+            print(f"STDERR:\n{result.stderr}", file=sys.stderr)
+        result.check_returncode()
+
+        data = json.loads(result.stdout)
         assert {"": "Print a JSON object of command descriptions by name.", "version": None} == data

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -122,3 +122,31 @@ def test_scie_base(tmp_path: Path, science_pyz: Path) -> None:
             )
         finally:
             shutil.rmtree(expanded_base, ignore_errors=True)
+
+
+def test_command_descriptions(tmp_path: Path, science_pyz: Path) -> None:
+    with resources.as_file(resources.files("data") / "command-descriptions.toml") as config:
+        subprocess.run(
+            args=[
+                sys.executable,
+                str(science_pyz),
+                "lift",
+                "build",
+                "--dest-dir",
+                str(tmp_path),
+                config,
+            ],
+            check=True,
+        )
+
+        exe_path = tmp_path / Platform.current().binary_name("command-descriptions")
+        scie_base = tmp_path / "scie-base"
+        data = json.loads(
+            subprocess.run(
+                args=[exe_path],
+                env={**os.environ, "PYTHON": "cpython310", "SCIE_BASE": str(scie_base)},
+                stdout=subprocess.PIPE,
+                check=True,
+            ).stdout
+        )
+        assert {"": "Print a JSON object of command descriptions by name.", "version": None} == data


### PR DESCRIPTION
Previously these were gathered from the TOML lift manifest but not
propagated to the JSON lift manifest in the built scie.

Fixes #43