### PR TITLE
Handle `~/.netrc` being a directory gracefully.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Release Notes
 
+## 0.4.3
+
+Fix science URL fetching code to gracefully ignore a `~/.netrc` that is a directory when configuring
+authentication for the fetch.
+
 ## 0.4.2
 
 Upgrade the science internal Python distribution to [PBS][PBS] CPython 3.12.4.

--- a/science/__init__.py
+++ b/science/__init__.py
@@ -3,6 +3,6 @@
 
 from packaging.version import Version
 
-__version__ = "0.4.2"
+__version__ = "0.4.3"
 
 VERSION = Version(__version__)

--- a/science/fetcher.py
+++ b/science/fetcher.py
@@ -75,7 +75,7 @@ def _configure_auth(url: Url) -> httpx.Auth | tuple[str, str] | None:
 
     try:
         return httpx.NetRCAuth(None)
-    except FileNotFoundError:
+    except (FileNotFoundError, IsADirectoryError):
         pass
     except NetrcParseError as e:
         logger.warning(f"Not using netrc for auth, netrc file is invalid: {e}")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,8 +4,13 @@
 import os
 import sys
 from pathlib import Path
+from typing import Iterator
 
 import pytest
+from click import Command, Context
+from click.globals import pop_context, push_context
+
+from science.context import ScienceConfig
 
 
 def pytest_sessionstart(session: pytest.Session) -> None:
@@ -26,3 +31,13 @@ def science_pyz() -> Path:
         return Path(os.environ["SCIENCE_TEST_PYZ_PATH"])
     except KeyError:
         pytest.fail("Test must be run via `nox` or `nox -etest`.")
+
+
+@pytest.fixture
+def cache_dir(tmp_path: Path) -> Iterator[Path]:
+    cache_dir = tmp_path / "nce"
+    push_context(Context(Command(None), obj=ScienceConfig(cache_dir=cache_dir)))
+    try:
+        yield cache_dir
+    finally:
+        pop_context()

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -1,0 +1,34 @@
+# Copyright 2024 Science project contributors.
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import shutil
+from pathlib import Path
+
+from pytest import MonkeyPatch
+from testing import issue
+
+from science.fetcher import fetch_text
+from science.model import Url
+
+
+@issue(71, ignore=True)
+def test_netrc_directory(_, tmp_path: Path, monkeypatch: MonkeyPatch, cache_dir: Path) -> None:
+    def assert_fetch() -> None:
+        # N.B.: Ensure a fresh, un-cached fetch.
+        shutil.rmtree(cache_dir, ignore_errors=True)
+        assert (
+            "7ed49bb4c50960d4ade3cf9a5614bd9c1190cc57d330492e36a7ace22b8ebc3b "
+            "*science-fat-linux-aarch64\n"
+        ) == fetch_text(
+            Url(
+                "https://github.com/a-scie/lift/releases/download/v0.4.2/"
+                "science-fat-linux-aarch64.sha256"
+            )
+        )
+
+    assert_fetch()
+
+    home_dir = tmp_path / "home"
+    monkeypatch.setenv("HOME", str(home_dir))
+    (home_dir / ".netrc").mkdir(parents=True)
+    assert_fetch()


### PR DESCRIPTION
Previously, this would cause fetcher code to fail when setting up
authentication.

Fixes #71