### PR TITLE
Add a generic install.sh and update README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ CPython 3.12 distribution by fetching it when the "thin" `science` binary is fir
 You can install the latest `science` release using the `install.sh` script like so:
 
 ```
-$ curl -LSsf https://raw.githubusercontent.com/a-scie/lift/main/install.sh | bash
+$ curl --proto '=https' --tlsv1.2 -LSsf https://raw.githubusercontent.com/a-scie/lift/main/install.sh | bash
 ...
 $ ~/bin/science -V
 ```

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ You can install the latest `science` release using the `install.sh` script like 
 ```
 $ curl --proto '=https' --tlsv1.2 -LSsf https://raw.githubusercontent.com/a-scie/lift/main/install.sh | bash
 ...
-$ ~/bin/science -V
+$ science -V
 ```
 
 The high level documentation is currently thin! The command line help is pretty decent though; so

--- a/README.md
+++ b/README.md
@@ -26,14 +26,12 @@ a result. The "thin" varieties have the CPython 3.12 distribution gouged out and
 result. In its place a [`ptex`](https://github.com/a-scie/ptex) binary is included that fills in the
 CPython 3.12 distribution by fetching it when the "thin" `science` binary is first run.
 
-I run on Linux x86_64; so I install a stable release like so:
+You can install the latest `science` release using the `install.sh` script like so:
+
 ```
-curl -fLO \
-  https://github.com/a-scie/lift/releases/download/v0.1.0/science-linux-x86_64
-curl -fL \
-  https://github.com/a-scie/lift/releases/download/v0.1.0/science-linux-x86_64.sha256 \
-  | sha256sum -c -
-chmod +x science-linux-x86_64 && mv science-linux-x86_64 ~/bin/science
+$ curl -LSsf https://raw.githubusercontent.com/a-scie/lift/main/install.sh | bash
+...
+$ ~/bin/science -V
 ```
 
 The high level documentation is currently thin! The command line help is pretty decent though; so

--- a/install.sh
+++ b/install.sh
@@ -134,7 +134,6 @@ function install_from_url() {
   fi
 
   green "Installed ${url} to ${dest}"
-
 }
 
 ensure_cmd cat

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2023 Science project contributors.
+# Copyright 2024 Science project contributors.
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 set -euo pipefail

--- a/install.sh
+++ b/install.sh
@@ -105,6 +105,8 @@ function sha256() {
 ensure_cmd dirname
 ensure_cmd mktemp
 ensure_cmd install
+ensure_cmd tr
+ensure_cmd mv
 function install_from_url() {
   local url="$1"
   local dest="$2"
@@ -117,6 +119,13 @@ function install_from_url() {
   fetch "${url}" "${workdir}" && green "Download completed successfully"
   (
     cd "${workdir}"
+
+    if [[ "${OS}" == "windows" ]]; then
+      # N.B. Windows sha256sum is sensitive to trailing \r in files.
+      cat *.sha256 | tr -d "\r" > out.sanitized
+      mv -f out.sanitized *.sha256
+    fi
+
     sha256 -c --status ./*.sha256 &&
       green "Download matched it's expected sha256 fingerprint, proceeding" ||
         die "Download from ${url} did not match the fingerprint at ${url}.sha256"

--- a/install.sh
+++ b/install.sh
@@ -2,6 +2,9 @@
 # Copyright 2024 Science project contributors.
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+# TEMPORARY: debug on windows
+set -x
+
 set -euo pipefail
 
 COLOR_RED="\x1b[31m"

--- a/install.sh
+++ b/install.sh
@@ -67,6 +67,19 @@ function determine_os() {
 
 OS="$(determine_os)"
 
+ensure_cmd arch
+function determine_arch() {
+  # Map platform architecture to released binary architecture.
+  read_arch="$(arch)"
+  case "$read_arch" in
+    x86_64*)   echo "x86_64" ;;
+    amd64*)    echo "x86_64" ;;
+    arm64*)    echo "aarch64" ;;
+    aarch64*)  echo "aarch64" ;;
+    *)        die "unknown arch: $(read_arch)" ;;
+  esac
+}
+
 ensure_cmd basename
 ensure_cmd $([[ "${OS}" == "windows" ]] && echo "pwsh" || echo "curl")
 function fetch() {
@@ -172,17 +185,7 @@ while (($# > 0)); do
   shift
 done
 
-# Map platform architecture to released binary architecture.
-READ_ARCH="$(arch)"
-case "$READ_ARCH" in
-  x86_64*)   ARCH="x86_64" ;;
-  amd64*)    ARCH="x86_64" ;;
-  arm64*)    ARCH="aarch64" ;;
-  aarch64*)  ARCH="aarch64" ;;
-  *)        echo "unknown arch: $(READ_ARCH)"; exit 1 ;;
-esac
-
-
+ARCH="$(determine_arch)"
 GITHUB_DOWNLOAD_BASE="https://github.com/a-scie/lift/releases/${VERSION}"
 INSTALL_DEST="${INSTALL_PREFIX}/${INSTALL_FILE}"
 DL_FILE="science-fat-${OS}-${ARCH}"

--- a/install.sh
+++ b/install.sh
@@ -115,12 +115,12 @@ function install_from_url() {
 
   fetch "${url}.sha256" "${workdir}"
   fetch "${url}" "${workdir}" && green "Download completed successfully"
-  # (
-  #   cd "${workdir}"
-  #   sha256 -c --status ./*.sha256 &&
-  #     green "Download matched it's expected sha256 fingerprint, proceeding" ||
-  #       die "Download from ${url} did not match the fingerprint at ${url}.sha256"
-  # )
+  (
+    cd "${workdir}"
+    sha256 -c --status ./*.sha256 &&
+      green "Download matched it's expected sha256 fingerprint, proceeding" ||
+        die "Download from ${url} did not match the fingerprint at ${url}.sha256"
+  )
   rm "${workdir}/"*.sha256
 
   if [[ "${OS}" == "macos" ]]; then

--- a/install.sh
+++ b/install.sh
@@ -192,7 +192,7 @@ done
 
 ARCH="$(determine_arch)"
 INSTALL_DEST="${INSTALL_PREFIX}/${INSTALL_FILE}"
-DL_EXT=$([[ "${OS}" == "macos" ]] && echo ".exe" || echo "")
+DL_EXT=$([[ "${OS}" == "windows" ]] && echo ".exe" || echo "")
 DL_URL="https://github.com/a-scie/lift/releases/${VERSION}/science-fat-${OS}-${ARCH}${DL_EXT}"
 
 green "Download URL is: ${DL_URL}"

--- a/install.sh
+++ b/install.sh
@@ -89,6 +89,7 @@ function fetch() {
   local dest
   dest="${dest_dir}/$(basename "${url}")"
 
+  # N.B. Curl is included on Windows 10+: https://devblogs.microsoft.com/commandline/tar-and-curl-come-to-windows/
   curl --proto '=https' --tlsv1.2 -SfL --progress-bar -o "${dest}" "${url}"
 }
 
@@ -114,6 +115,9 @@ function install_from_url() {
 
   fetch "${url}.sha256" "${workdir}"
   fetch "${url}" "${workdir}" && green "Download completed successfully"
+  echo "======================================"
+  ls -al "${workdir}"
+  echo "======================================"
   (
     cd "${workdir}"
     sha256 -c --status ./*.sha256 &&

--- a/install.sh
+++ b/install.sh
@@ -2,9 +2,6 @@
 # Copyright 2024 Science project contributors.
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-# TEMPORARY: debug on windows
-set -x
-
 set -euo pipefail
 
 COLOR_RED="\x1b[31m"

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+#
+# A basic install wrapper for UNIX-based systems.
+#
+
+GITHUB_CHANGES_FILE="https://raw.githubusercontent.com/a-scie/lift/main/CHANGES.md"
+GITHUB_DOWNLOAD_BASE="https://github.com/a-scie/lift/releases/download"
+
+# Check if curl is available.
+if ! command -v curl &> /dev/null; then
+  echo "Error: curl command not found. Please install curl and try again." >&2
+  exit 1
+fi
+
+# Check if arch is available.
+if ! command -v arch &> /dev/null; then
+  echo "Error: arch command not found. Please install arch and try again." >&2
+  exit 1
+fi
+
+# Map platform architecture to released binary architecture.
+READ_ARCH="$(arch)"
+case "$READ_ARCH" in
+  x86_64*)   ARCH="x86_64" ;;
+  arm64*)    ARCH="aarch64" ;;
+  aarch64*)  ARCH="aarch64" ;;
+  *)        echo "unknown arch: $(READ_ARCH)"; exit 1 ;;
+esac
+
+# Map OS name to released binary OS names and platform-specific SHA checker invocation.
+case "$OSTYPE" in
+  darwin*)  OS="macos" SHASUM_CMD="shasum -a 256 -c -" ;;
+  linux*)   OS="linux" SHASUM_CMD="sha256sum -c -" ;;
+  *)        echo "unknown platform: ${OSTYPE}"; exit 1 ;;
+esac
+
+CHANGES_CONTENT=$(curl -s "${GITHUB_CHANGES_FILE}")
+if [ $? -ne 0 ]; then
+  echo "Error: Failed to fetch ${GITHUB_CHANGES_FILE} from $url" >&2
+  exit 1
+fi
+
+CURRENT_VERSION=$(echo "$CHANGES_CONTENT" | grep -m 1 '^#\+ [0-9]' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+if [ -z "$CURRENT_VERSION" ]; then
+  echo "Error: No version number found in ${GITHUB_CHANGES_FILE}" >&2
+  exit 1
+fi
+
+DL_FILE="science-fat-${OS}-${ARCH}"
+DL_URL="${GITHUB_DOWNLOAD_BASE}/v${CURRENT_VERSION}/${DL_FILE}"
+SHA_URL="${DL_URL}.sha256"
+
+echo "Download URL is: ${DL_URL}"
+echo "Checksum URL is: ${SHA_URL}"
+
+curl -fLO --progress-bar "$DL_URL" && \
+  curl -fL --progress-bar "$SHA_URL" | ${SHASUM_CMD} && \
+  chmod +x "$DL_FILE" && \
+  mv -v "$DL_FILE" ~/bin/science

--- a/install.sh
+++ b/install.sh
@@ -115,15 +115,12 @@ function install_from_url() {
 
   fetch "${url}.sha256" "${workdir}"
   fetch "${url}" "${workdir}" && green "Download completed successfully"
-  echo "======================================"
-  ls -al "${workdir}"
-  echo "======================================"
-  (
-    cd "${workdir}"
-    sha256 -c --status ./*.sha256 &&
-      green "Download matched it's expected sha256 fingerprint, proceeding" ||
-        die "Download from ${url} did not match the fingerprint at ${url}.sha256"
-  )
+  # (
+  #   cd "${workdir}"
+  #   sha256 -c --status ./*.sha256 &&
+  #     green "Download matched it's expected sha256 fingerprint, proceeding" ||
+  #       die "Download from ${url} did not match the fingerprint at ${url}.sha256"
+  # )
   rm "${workdir}/"*.sha256
 
   if [[ "${OS}" == "macos" ]]; then

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Copyright 2024 Science project contributors.
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
-
+set -x
 set -euo pipefail
 
 COLOR_RED="\x1b[31m"

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Copyright 2024 Science project contributors.
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
-set -x
+
 set -euo pipefail
 
 COLOR_RED="\x1b[31m"

--- a/install.sh
+++ b/install.sh
@@ -192,7 +192,8 @@ done
 
 ARCH="$(determine_arch)"
 INSTALL_DEST="${INSTALL_PREFIX}/${INSTALL_FILE}"
-DL_URL="https://github.com/a-scie/lift/releases/${VERSION}/science-fat-${OS}-${ARCH}"
+DL_EXT=$([[ "${OS}" == "macos" ]] && echo ".exe" || echo "")
+DL_URL="https://github.com/a-scie/lift/releases/${VERSION}/science-fat-${OS}-${ARCH}${DL_EXT}"
 
 green "Download URL is: ${DL_URL}"
 install_from_url "${DL_URL}" "${INSTALL_DEST}"

--- a/install.sh
+++ b/install.sh
@@ -81,24 +81,15 @@ function determine_arch() {
 }
 
 ensure_cmd basename
-ensure_cmd $([[ "${OS}" == "windows" ]] && echo "pwsh" || echo "curl")
+ensure_cmd curl
 function fetch() {
-  set -x
   local url="$1"
   local dest_dir="$2"
 
   local dest
   dest="${dest_dir}/$(basename "${url}")"
 
-  if [[ "${OS}" == "windows" ]]; then
-    ensure_cmd cygpath
-    local windows_outfile
-    windows_outfile="$(cygpath -w "${dest}")"
-    pwsh -c "Invoke-WebRequest -OutFile '${windows_outfile}' -Uri ${url}" 2>&1
-  else
-    curl --proto '=https' --tlsv1.2 -SfL --progress-bar -o "${dest}" "${url}"
-  fi
-  set +x
+  curl --proto '=https' --tlsv1.2 -SfL --progress-bar -o "${dest}" "${url}"
 }
 
 ensure_cmd $([[ "${OS}" == "macos" ]] && echo "shasum" || echo "sha256sum")

--- a/install.sh
+++ b/install.sh
@@ -192,10 +192,8 @@ while (($# > 0)); do
 done
 
 ARCH="$(determine_arch)"
-GITHUB_DOWNLOAD_BASE="https://github.com/a-scie/lift/releases/${VERSION}"
 INSTALL_DEST="${INSTALL_PREFIX}/${INSTALL_FILE}"
-DL_FILE="science-fat-${OS}-${ARCH}"
-DL_URL="${GITHUB_DOWNLOAD_BASE}/${DL_FILE}"
+DL_URL="https://github.com/a-scie/lift/releases/${VERSION}/science-fat-${OS}-${ARCH}"
 
 green "Download URL is: ${DL_URL}"
 install_from_url "${DL_URL}" "${INSTALL_DEST}"

--- a/install.sh
+++ b/install.sh
@@ -28,15 +28,149 @@ function warn() {
 
 function ensure_cmd() {
   local cmd="$1"
-  command -v "$cmd" > /dev/null || die "This script requires the ${cmd} binary to be on the PATH."
+  command -v "$cmd" > /dev/null || die "This script requires the ${cmd} binary to be on \$PATH."
 }
 
-GITHUB_DOWNLOAD_BASE="https://github.com/a-scie/lift/releases/latest/download"
+_GC=()
+
+ensure_cmd rm
+function gc() {
+  if (($# > 0)); then
+    _GC+=("$@")
+  else
+    # Check $_GC validity to avoid "unbound variable" warnings if gc w/ arguments is never called.
+    if ! [ ${#_GC[@]} -eq 0 ]; then
+      rm -rf "${_GC[@]}"
+    fi
+  fi
+}
+
+trap gc EXIT
+
+ensure_cmd uname
+function determine_os() {
+  local os
+
+  os="$(uname -s)"
+  if [[ "${os}" =~ [Ll]inux ]]; then
+    echo linux
+  elif [[ "${os}" =~ [Dd]arwin ]]; then
+    echo macos
+  elif [[ "${os}" =~ [Ww]in|[Mm][Ii][Nn][Gg] ]]; then
+    # Powershell reports something like: Windows_NT
+    # Git bash reports something like: MINGW64_NT-10.0-22621
+    echo windows
+  else
+    die "Science is not supported on this OS (${os}). Please reach out at https://github.com/a-scie/lift/issues for help."
+  fi
+}
+
+OS="$(determine_os)"
+
+ensure_cmd basename
+ensure_cmd $([[ "${OS}" == "windows" ]] && echo "pwsh" || echo "curl")
+function fetch() {
+  local url="$1"
+  local dest_dir="$2"
+
+  local dest
+  dest="${dest_dir}/$(basename "${url}")"
+
+  if [[ "${OS}" == "windows" ]]; then
+    pwsh -c "Invoke-WebRequest -OutFile ${dest} -Uri ${url}"
+  else
+    curl --proto '=https' --tlsv1.2 -sSfL -o "${dest}" "${url}"
+  fi
+}
+
+ensure_cmd $([[ "${OS}" == "macos" ]] && echo "shasum" || echo "sha256sum")
+function sha256() {
+  if [[ "${OS}" == "macos" ]]; then
+    shasum --algorithm 256 "$@"
+  else
+    sha256sum "$@"
+  fi
+}
+
+ensure_cmd mktemp
+ensure_cmd install
+function install_from_url() {
+  local url="$1"
+  local dest="$2"
+
+  local workdir
+  workdir="$(mktemp -d)"
+  gc "${workdir}"
+
+  fetch "${url}.sha256" "${workdir}"
+  fetch "${url}" "${workdir}"
+  (
+    cd "${workdir}"
+    sha256 -c --status ./*.sha256 ||
+      die "Download from ${url} did not match the fingerprint at ${url}.sha256"
+  )
+  rm "${workdir}/"*.sha256
+  if [[ "${OS}" == "macos" ]]; then
+    mkdir -p "$(dirname "${dest}")"
+    install -m 755 "${workdir}/"* "${dest}"
+  else
+    install -D -m 755 "${workdir}/"* "${dest}"
+  fi
+}
+
+ensure_cmd cat
+function usage() {
+  cat << __EOF__
+Usage: $0
+
+Installs the \`science\` binary.
+
+-h | --help: Print this help message.
+
+-d | --bin-dir:
+  The directory to install the science binary in, "~/.local/bin" by default.
+
+-b | --base-name:
+  The name to use for the science binary, "science" by default.
+
+-V | --version:
+  The version of the science binary to install, the latest version by default.
+  The available versions can be seen at:
+    https://github.com/a-scie/lift/releases
+
+__EOF__
+}
+
 INSTALL_PREFIX="${HOME}/.local/bin"
 INSTALL_FILE="science"
-INSTALL_DEST="${INSTALL_PREFIX}/${INSTALL_FILE}"
+VERSION="latest/download"
 
-ensure_cmd arch
+# Parse arguments.
+while (($# > 0)); do
+  case "$1" in
+    --help | -h)
+      usage
+      exit 0
+      ;;
+    --bin-dir | -d)
+      INSTALL_PREFIX="$2"
+      shift
+      ;;
+    --base-name | -b)
+      INSTALL_FILE="$2"
+      shift
+      ;;
+    --version | -V)
+      VERSION="download/v${2}"
+      shift
+      ;;
+    *)
+      usage
+      die "Unexpected argument: ${1}\n"
+      ;;
+  esac
+  shift
+done
 
 # Map platform architecture to released binary architecture.
 READ_ARCH="$(arch)"
@@ -48,32 +182,18 @@ case "$READ_ARCH" in
   *)        echo "unknown arch: $(READ_ARCH)"; exit 1 ;;
 esac
 
-# Map OS name to released binary OS names and platform-specific SHA checker invocation.
-case "$OSTYPE" in
-  darwin*)  OS="macos" SHASUM_TOOL="shasum" SHASUM_CMD="${SHASUM_TOOL} -a 256 -c -" ;;
-  linux*)   OS="linux" SHASUM_TOOL="sha256sum" SHASUM_CMD="${SHASUM_TOOL} -c -" ;;
-  msys*)    OS="windows" SHASUM_TOOL="sha256sum" SHASUM_CMD="${SHASUM_TOOL} -c -" ;;
-  *)        echo "unsupported platform: ${OSTYPE}, please download manually from https://github.com/a-scie/lift/releases/"; exit 1 ;;
-esac
 
-ensure_cmd "${SHASUM_TOOL}"
-ensure_cmd curl
-
+GITHUB_DOWNLOAD_BASE="https://github.com/a-scie/lift/releases/${VERSION}"
+INSTALL_DEST="${INSTALL_PREFIX}/${INSTALL_FILE}"
 DL_FILE="science-fat-${OS}-${ARCH}"
 DL_URL="${GITHUB_DOWNLOAD_BASE}/${DL_FILE}"
-SHA_URL="${DL_URL}.sha256"
 
 green "Download URL is: ${DL_URL}"
-green "Checksum URL is: ${SHA_URL}"
 
 log "Ensuring ${INSTALL_PREFIX}"
 mkdir -p "${INSTALL_PREFIX}"
 
-curl -fLO --progress-bar "$DL_URL" && \
-  curl -fL --progress-bar "$SHA_URL" | ${SHASUM_CMD} && \
-  chmod +x "$DL_FILE" && \
-  mv -v "$DL_FILE" "${INSTALL_DEST}"
-
+install_from_url "${DL_URL}" "${INSTALL_DEST}"
 green "Installed ${DL_FILE} to ${INSTALL_DEST}"
 
 # Warn if the install prefix is not on $PATH.

--- a/install.sh
+++ b/install.sh
@@ -1,16 +1,11 @@
 #!/bin/bash
 #
-# A basic install wrapper for UNIX-based systems.
+# A basic install wrapper for UNIX-based environments.
 #
 
-GITHUB_CHANGES_FILE="https://raw.githubusercontent.com/a-scie/lift/main/CHANGES.md"
 GITHUB_DOWNLOAD_BASE="https://github.com/a-scie/lift/releases/latest/download"
-
-# Check if curl is available.
-if ! command -v curl &> /dev/null; then
-  echo "Error: curl command not found. Please install curl and try again." >&2
-  exit 1
-fi
+INSTALL_PREFIX="${HOME}/.local/bin"
+INSTALL_DEST="${INSTALL_PREFIX}/science"
 
 # Check if arch is available.
 if ! command -v arch &> /dev/null; then
@@ -22,6 +17,7 @@ fi
 READ_ARCH="$(arch)"
 case "$READ_ARCH" in
   x86_64*)   ARCH="x86_64" ;;
+  amd64*)    ARCH="x86_64" ;;
   arm64*)    ARCH="aarch64" ;;
   aarch64*)  ARCH="aarch64" ;;
   *)        echo "unknown arch: $(READ_ARCH)"; exit 1 ;;
@@ -29,10 +25,23 @@ esac
 
 # Map OS name to released binary OS names and platform-specific SHA checker invocation.
 case "$OSTYPE" in
-  darwin*)  OS="macos" SHASUM_CMD="shasum -a 256 -c -" ;;
-  linux*)   OS="linux" SHASUM_CMD="sha256sum -c -" ;;
-  *)        echo "unknown platform: ${OSTYPE}"; exit 1 ;;
+  darwin*)  OS="macos" SHASUM_TOOL="shasum" SHASUM_CMD="${SHASUM_TOOL} -a 256 -c -" ;;
+  linux*)   OS="linux" SHASUM_TOOL="sha256sum" SHASUM_CMD="${SHASUM_TOOL} -c -" ;;
+  msys*)    OS="windows" SHASUM_TOOL="sha256sum" SHASUM_CMD="${SHASUM_TOOL} -c -" ;;
+  *)        echo "unsupported platform: ${OSTYPE}, please download manually from https://github.com/a-scie/lift/releases/"; exit 1 ;;
 esac
+
+# Check if a sha sum checking tool is available.
+if ! command -v "${SHASUM_TOOL}" &> /dev/null; then
+  echo "Error: ${SHASUM_TOOL} command not found. Please install ${SHASUM_TOOL} and try again." >&2
+  exit 1
+fi
+
+# Check if curl is available.
+if ! command -v curl &> /dev/null; then
+  echo "Error: curl command not found. Please install curl and try again." >&2
+  exit 1
+fi
 
 DL_FILE="science-fat-${OS}-${ARCH}"
 DL_URL="${GITHUB_DOWNLOAD_BASE}/${DL_FILE}"
@@ -41,7 +50,12 @@ SHA_URL="${DL_URL}.sha256"
 echo "Download URL is: ${DL_URL}"
 echo "Checksum URL is: ${SHA_URL}"
 
+echo "Ensuring ${INSTALL_PREFIX}"
+mkdir -p "${INSTALL_PREFIX}"
+
 curl -fLO --progress-bar "$DL_URL" && \
   curl -fL --progress-bar "$SHA_URL" | ${SHASUM_CMD} && \
   chmod +x "$DL_FILE" && \
-  mv -v "$DL_FILE" ~/bin/science
+  mv -v "$DL_FILE" "${INSTALL_DEST}"
+
+echo "Installed ${DL_FILE} to ${INSTALL_DEST} - please ensure that ${INSTALL_PREFIX} is on your \$PATH"

--- a/install.sh
+++ b/install.sh
@@ -39,7 +39,7 @@ function gc() {
   if (($# > 0)); then
     _GC+=("$@")
   else
-    # Check $_GC validity to avoid "unbound variable" warnings if gc w/ arguments is never called.
+    # Check if $_GC has members to avoid "unbound variable" warnings if gc w/ arguments is never called.
     if ! [ ${#_GC[@]} -eq 0 ]; then
       rm -rf "${_GC[@]}"
     fi

--- a/install.sh
+++ b/install.sh
@@ -109,6 +109,7 @@ ensure_cmd dirname
 ensure_cmd mktemp
 ensure_cmd install
 function install_from_url() {
+  set -x
   local url="$1"
   local dest="$2"
 
@@ -134,6 +135,7 @@ function install_from_url() {
   fi
 
   green "Installed ${url} to ${dest}"
+  set +x
 }
 
 ensure_cmd cat

--- a/install.sh
+++ b/install.sh
@@ -90,7 +90,12 @@ function fetch() {
   dest="${dest_dir}/$(basename "${url}")"
 
   if [[ "${OS}" == "windows" ]]; then
-    pwsh -c "Invoke-WebRequest -Uri ${url}" > "${dest}"
+    set -x
+    ensure_cmd cygpath
+    local outfile
+    windows_outfile="$(cygpath -w "${dest}")"
+    pwsh -c "Invoke-WebRequest -OutFile ${windows_outfile} -Uri ${url}"
+    set +x
   else
     curl --proto '=https' --tlsv1.2 -SfL --progress-bar -o "${dest}" "${url}"
   fi

--- a/install.sh
+++ b/install.sh
@@ -194,7 +194,6 @@ DL_FILE="science-fat-${OS}-${ARCH}"
 DL_URL="${GITHUB_DOWNLOAD_BASE}/${DL_FILE}"
 
 green "Download URL is: ${DL_URL}"
-
 install_from_url "${DL_URL}" "${INSTALL_DEST}"
 green "Installed ${DL_FILE} to ${INSTALL_DEST}"
 

--- a/install.sh
+++ b/install.sh
@@ -4,7 +4,7 @@
 #
 
 GITHUB_CHANGES_FILE="https://raw.githubusercontent.com/a-scie/lift/main/CHANGES.md"
-GITHUB_DOWNLOAD_BASE="https://github.com/a-scie/lift/releases/download"
+GITHUB_DOWNLOAD_BASE="https://github.com/a-scie/lift/releases/latest/download"
 
 # Check if curl is available.
 if ! command -v curl &> /dev/null; then
@@ -34,20 +34,8 @@ case "$OSTYPE" in
   *)        echo "unknown platform: ${OSTYPE}"; exit 1 ;;
 esac
 
-CHANGES_CONTENT=$(curl -s "${GITHUB_CHANGES_FILE}")
-if [ $? -ne 0 ]; then
-  echo "Error: Failed to fetch ${GITHUB_CHANGES_FILE} from $url" >&2
-  exit 1
-fi
-
-CURRENT_VERSION=$(echo "$CHANGES_CONTENT" | grep -m 1 '^#\+ [0-9]' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
-if [ -z "$CURRENT_VERSION" ]; then
-  echo "Error: No version number found in ${GITHUB_CHANGES_FILE}" >&2
-  exit 1
-fi
-
 DL_FILE="science-fat-${OS}-${ARCH}"
-DL_URL="${GITHUB_DOWNLOAD_BASE}/v${CURRENT_VERSION}/${DL_FILE}"
+DL_URL="${GITHUB_DOWNLOAD_BASE}/${DL_FILE}"
 SHA_URL="${DL_URL}.sha256"
 
 echo "Download URL is: ${DL_URL}"

--- a/install.sh
+++ b/install.sh
@@ -90,7 +90,7 @@ function fetch() {
   dest="${dest_dir}/$(basename "${url}")"
 
   if [[ "${OS}" == "windows" ]]; then
-    pwsh -c "Invoke-WebRequest -OutFile ${dest} -Uri ${url}"
+    pwsh -c "Invoke-WebRequest -Uri ${url}" > "${dest}"
   else
     curl --proto '=https' --tlsv1.2 -SfL --progress-bar -o "${dest}" "${url}"
   fi

--- a/install.sh
+++ b/install.sh
@@ -124,6 +124,7 @@ function install_from_url() {
       die "Download from ${url} did not match the fingerprint at ${url}.sha256"
   )
   rm "${workdir}/"*.sha256
+
   if [[ "${OS}" == "macos" ]]; then
     mkdir -p "$(dirname "${dest}")"
     install -m 755 "${workdir}/"* "${dest}"
@@ -193,9 +194,6 @@ DL_FILE="science-fat-${OS}-${ARCH}"
 DL_URL="${GITHUB_DOWNLOAD_BASE}/${DL_FILE}"
 
 green "Download URL is: ${DL_URL}"
-
-log "Ensuring ${INSTALL_PREFIX}"
-mkdir -p "${INSTALL_PREFIX}"
 
 install_from_url "${DL_URL}" "${INSTALL_DEST}"
 green "Installed ${DL_FILE} to ${INSTALL_DEST}"

--- a/install.sh
+++ b/install.sh
@@ -109,7 +109,6 @@ ensure_cmd dirname
 ensure_cmd mktemp
 ensure_cmd install
 function install_from_url() {
-  set -x
   local url="$1"
   local dest="$2"
 
@@ -135,7 +134,6 @@ function install_from_url() {
   fi
 
   green "Installed ${url} to ${dest}"
-  set +x
 }
 
 ensure_cmd cat
@@ -193,7 +191,8 @@ while (($# > 0)); do
 done
 
 ARCH="$(determine_arch)"
-INSTALL_DEST="${INSTALL_PREFIX}/${INSTALL_FILE}"
+DIRSEP=$([[ "${OS}" == "windows" ]] && echo "\\" || echo "/")
+INSTALL_DEST="${INSTALL_PREFIX}${DIRSEP}${INSTALL_FILE}"
 DL_EXT=$([[ "${OS}" == "windows" ]] && echo ".exe" || echo "")
 DL_URL="https://github.com/a-scie/lift/releases/${VERSION}/science-fat-${OS}-${ARCH}${DL_EXT}"
 

--- a/install.sh
+++ b/install.sh
@@ -31,6 +31,7 @@ function ensure_cmd() {
   command -v "$cmd" > /dev/null || die "This script requires the ${cmd} binary to be on \$PATH."
 }
 
+ISSUES_URL="https://github.com/a-scie/lift/issues"
 _GC=()
 
 ensure_cmd rm
@@ -56,12 +57,12 @@ function determine_os() {
     echo linux
   elif [[ "${os}" =~ [Dd]arwin ]]; then
     echo macos
-  elif [[ "${os}" =~ [Ww]in|[Mm][Ii][Nn][Gg] ]]; then
+  elif [[ "${os}" =~ [Ww]indow|[Mm][Ii][Nn][Gg] ]]; then
     # Powershell reports something like: Windows_NT
     # Git bash reports something like: MINGW64_NT-10.0-22621
     echo windows
   else
-    die "Science is not supported on this OS (${os}). Please reach out at https://github.com/a-scie/lift/issues for help."
+    die "Science is not supported on this OS (${os}). Please reach out at ${ISSUES_URL} for help."
   fi
 }
 

--- a/install.sh
+++ b/install.sh
@@ -83,6 +83,7 @@ function determine_arch() {
 ensure_cmd basename
 ensure_cmd $([[ "${OS}" == "windows" ]] && echo "pwsh" || echo "curl")
 function fetch() {
+  set -x
   local url="$1"
   local dest_dir="$2"
 
@@ -90,15 +91,14 @@ function fetch() {
   dest="${dest_dir}/$(basename "${url}")"
 
   if [[ "${OS}" == "windows" ]]; then
-    set -x
     ensure_cmd cygpath
-    local outfile
+    local windows_outfile
     windows_outfile="$(cygpath -w "${dest}")"
-    pwsh -c "Invoke-WebRequest -OutFile ${windows_outfile} -Uri ${url}"
-    set +x
+    pwsh -c "Invoke-WebRequest -OutFile '${windows_outfile}' -Uri ${url}" 2>&1
   else
     curl --proto '=https' --tlsv1.2 -SfL --progress-bar -o "${dest}" "${url}"
   fi
+  set +x
 }
 
 ensure_cmd $([[ "${OS}" == "macos" ]] && echo "shasum" || echo "sha256sum")

--- a/install.sh
+++ b/install.sh
@@ -68,16 +68,15 @@ function determine_os() {
 
 OS="$(determine_os)"
 
-ensure_cmd arch
 function determine_arch() {
   # Map platform architecture to released binary architecture.
-  read_arch="$(arch)"
+  read_arch="$(uname -m)"
   case "$read_arch" in
     x86_64*)   echo "x86_64" ;;
     amd64*)    echo "x86_64" ;;
     arm64*)    echo "aarch64" ;;
     aarch64*)  echo "aarch64" ;;
-    *)        die "unknown arch: $(read_arch)" ;;
+    *)        die "unknown arch: ${read_arch}" ;;
   esac
 }
 
@@ -106,6 +105,7 @@ function sha256() {
   fi
 }
 
+ensure_cmd dirname
 ensure_cmd mktemp
 ensure_cmd install
 function install_from_url() {

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -16,7 +16,14 @@ IS_WINDOWS_X86 = Platform.current() == Platform.Windows_x86_64
 @pytest.fixture(scope="module")
 def installer(build_root: Path) -> list:
     installer = build_root / "install.sh"
-    return [Path(r"C:\Program Files\Git\bin\bash.EXE"), installer] if IS_WINDOWS else [installer]
+    # Windows has no shebang support, nor a native bash install.
+    if IS_WINDOWS:
+        # If the Windows environment has git installed, git vendors a bash we can reliably use.
+        git_bash = Path(r"C:\Program Files\Git\bin\bash.EXE")
+        # If that doesn't exist, fallback to WSL bash.
+        return [git_bash if git_bash.exists() else "bash.exe", installer]
+    else:
+        return [installer]
 
 
 def run_captured(cmd: list):

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -1,7 +1,6 @@
 # Copyright 2024 Science project contributors.
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-import os
 import subprocess
 
 from _pytest.tmpdir import TempPathFactory
@@ -15,16 +14,18 @@ def test_installer_help():
     assert "--help" in subprocess.check_output([INSTALLER, "--help"]).decode("utf-8")
 
 
-def test_installer_fetch_default():
-    """Invokes install.sh (a shell script) to fetch the latest science release binary, then invokes it."""
-    assert "success" in subprocess.check_output([INSTALLER], stderr=subprocess.STDOUT).decode(
-        "utf-8"
-    )
-    assert subprocess.check_output([os.path.expanduser("~/.local/bin/science"), "-V"]).strip()
+def test_installer_fetch_latest(tmp_path_factory: TempPathFactory):
+    """Invokes install.sh to fetch the latest science release binary, then invokes it."""
+    test_dir = tmp_path_factory.mktemp("install-test-default")
+    assert "success" in subprocess.check_output(
+        [INSTALLER, "-d", f"{test_dir}/bin"],
+        stderr=subprocess.STDOUT,
+    ).decode("utf-8")
+    assert subprocess.check_output([f"{test_dir}/bin/science", "-V"]).strip()
 
 
 def test_installer_fetch_argtest(tmp_path_factory: TempPathFactory):
-    """Validates all the other options in the installer."""
+    """Exercises all the options in the installer."""
     test_dir = tmp_path_factory.mktemp("install-test")
     output = subprocess.check_output(
         [INSTALLER, "-V", "0.6.1", "-b", "science061", "-d", f"{test_dir}/bin"],

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -52,9 +52,7 @@ def test_installer_fetch_argtest(tmp_path_factory: TempPathFactory, installer: l
     assert "success" in result.stderr, "Expected 'success' in tool stderr logging"
 
     # Ensure missing $PATH entry warning (assumes our temp dir by nature is not on $PATH).
-    assert (
-        f"WARNING: {bin_dir} is not detected on $PATH" in result.stderr
-    ), "Expected missing $PATH entry warning"
+    assert "is not detected on $PATH" in result.stderr, "Expected missing $PATH entry warning"
 
     # Check expected versioned binary exists.
     assert (result := run_captured([bin_dir / bin_file, "-V"])).returncode == 0

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -1,0 +1,42 @@
+# Copyright 2024 Science project contributors.
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import os
+import subprocess
+
+from _pytest.tmpdir import TempPathFactory
+
+INSTALLER = "./install.sh"
+
+
+def test_installer_help():
+    """Validates -h|--help in the installer."""
+    assert "--help" in subprocess.check_output([INSTALLER, "-h"]).decode("utf-8")
+    assert "--help" in subprocess.check_output([INSTALLER, "--help"]).decode("utf-8")
+
+
+def test_installer_fetch_default():
+    """Invokes install.sh (a shell script) to fetch the latest science release binary, then invokes it."""
+    assert "success" in subprocess.check_output([INSTALLER], stderr=subprocess.STDOUT).decode(
+        "utf-8"
+    )
+    assert subprocess.check_output([os.path.expanduser("~/.local/bin/science"), "-V"]).strip()
+
+
+def test_installer_fetch_argtest(tmp_path_factory: TempPathFactory):
+    """Validates all the other options in the installer."""
+    test_dir = tmp_path_factory.mktemp("install-test")
+    output = subprocess.check_output(
+        [INSTALLER, "-V", "0.6.1", "-b", "science061", "-d", f"{test_dir}/bin"],
+        stderr=subprocess.STDOUT,
+    ).decode("utf-8")
+    assert "success" in output
+
+    # Ensure missing $PATH entry warning.
+    assert f"WARNING: {test_dir}/bin is not detected on $PATH" in output
+
+    # Check expected versioned binary exists.
+    assert (
+        subprocess.check_output([f"{test_dir}/bin/science061", "-V"]).decode("utf-8").strip()
+        == "0.6.1"
+    )

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -13,7 +13,7 @@ from science.os import IS_WINDOWS
 @pytest.fixture(scope="module")
 def installer(build_root: Path) -> list:
     installer = build_root / "install.sh"
-    return ["bash", installer] if IS_WINDOWS else [installer]
+    return [r"C:\Program Files\Git\bin\bash.EXE", installer] if IS_WINDOWS else [installer]
 
 
 def run_captured(cmd: list):

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -7,42 +7,45 @@ from pathlib import Path
 import pytest
 from _pytest.tmpdir import TempPathFactory
 
+from science.os import IS_WINDOWS
+
 
 @pytest.fixture(scope="module")
-def installer(build_root: Path) -> Path:
-    return build_root / "install.sh"
+def installer(build_root: Path) -> list:
+    installer = build_root / "install.sh"
+    return ["bash", installer] if IS_WINDOWS else [installer]
 
 
 def run_captured(cmd: list):
     return subprocess.run(cmd, capture_output=True, text=True)
 
 
-def test_installer_help(installer: Path):
+def test_installer_help(installer: list):
     """Validates -h|--help in the installer."""
     for tested_flag in ("-h", "--help"):
-        assert (result := run_captured([installer, tested_flag])).returncode == 0
+        assert (result := run_captured(installer + [tested_flag])).returncode == 0
         assert "--help" in result.stdout, "Expected '--help' in tool output"
 
 
-def test_installer_fetch_latest(tmp_path_factory: TempPathFactory, installer: Path):
+def test_installer_fetch_latest(tmp_path_factory: TempPathFactory, installer: list):
     """Invokes install.sh to fetch the latest science release binary, then invokes it."""
     test_dir = tmp_path_factory.mktemp("install-test-default")
 
-    assert (result := run_captured([installer, "-d", f"{test_dir}/bin"])).returncode == 0
+    assert (result := run_captured(installer + ["-d", f"{test_dir}/bin"])).returncode == 0
     assert "success" in result.stderr, "Expected 'success' in tool stderr logging"
 
     assert (result := run_captured([f"{test_dir}/bin/science", "-V"])).returncode == 0
     assert result.stdout.strip(), "Expected version output in tool stdout"
 
 
-def test_installer_fetch_argtest(tmp_path_factory: TempPathFactory, installer: Path):
+def test_installer_fetch_argtest(tmp_path_factory: TempPathFactory, installer: list):
     """Exercises all the options in the installer."""
     test_dir = tmp_path_factory.mktemp("install-test")
     test_ver = "0.6.1"
 
     assert (
         result := run_captured(
-            [installer, "-V", test_ver, "-b", f"science{test_ver}", "-d", f"{test_dir}/bin"]
+            installer + ["-V", test_ver, "-b", f"science{test_ver}", "-d", f"{test_dir}/bin"]
         )
     ).returncode == 0
     assert "success" in result.stderr, "Expected 'success' in tool stderr logging"

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -13,36 +13,47 @@ def installer(build_root: Path) -> Path:
     return build_root / "install.sh"
 
 
+def run_captured(cmd: list):
+    return subprocess.run(cmd, capture_output=True, text=True)
+
+
 def test_installer_help(installer: Path):
     """Validates -h|--help in the installer."""
-    assert "--help" in subprocess.check_output([installer, "-h"]).decode("utf-8")
-    assert "--help" in subprocess.check_output([installer, "--help"]).decode("utf-8")
+    for tested_flag in ("-h", "--help"):
+        assert (result := run_captured([installer, tested_flag])).returncode == 0
+        assert "--help" in result.stdout, "Expected '--help' in tool output"
 
 
 def test_installer_fetch_latest(tmp_path_factory: TempPathFactory, installer: Path):
     """Invokes install.sh to fetch the latest science release binary, then invokes it."""
     test_dir = tmp_path_factory.mktemp("install-test-default")
-    assert "success" in subprocess.check_output(
-        [installer, "-d", f"{test_dir}/bin"],
-        stderr=subprocess.STDOUT,
-    ).decode("utf-8")
-    assert subprocess.check_output([f"{test_dir}/bin/science", "-V"]).strip()
+
+    assert (result := run_captured([installer, "-d", f"{test_dir}/bin"])).returncode == 0
+    assert "success" in result.stderr, "Expected 'success' in tool stderr logging"
+
+    assert (result := run_captured([f"{test_dir}/bin/science", "-V"])).returncode == 0
+    assert result.stdout.strip(), "Expected version output in tool stdout"
 
 
 def test_installer_fetch_argtest(tmp_path_factory: TempPathFactory, installer: Path):
     """Exercises all the options in the installer."""
     test_dir = tmp_path_factory.mktemp("install-test")
-    output = subprocess.check_output(
-        [installer, "-V", "0.6.1", "-b", "science061", "-d", f"{test_dir}/bin"],
-        stderr=subprocess.STDOUT,
-    ).decode("utf-8")
-    assert "success" in output
+    test_ver = "0.6.1"
 
-    # Ensure missing $PATH entry warning.
-    assert f"WARNING: {test_dir}/bin is not detected on $PATH" in output
+    assert (
+        result := run_captured(
+            [installer, "-V", test_ver, "-b", f"science{test_ver}", "-d", f"{test_dir}/bin"]
+        )
+    ).returncode == 0
+    assert "success" in result.stderr, "Expected 'success' in tool stderr logging"
+
+    # Ensure missing $PATH entry warning (assumes our temp dir by nature is not on $PATH).
+    assert (
+        f"WARNING: {test_dir}/bin is not detected on $PATH" in result.stderr
+    ), "Expected missing $PATH entry warning"
 
     # Check expected versioned binary exists.
+    assert (result := run_captured([f"{test_dir}/bin/science{test_ver}", "-V"])).returncode == 0
     assert (
-        subprocess.check_output([f"{test_dir}/bin/science061", "-V"]).decode("utf-8").strip()
-        == "0.6.1"
-    )
+        result.stdout.strip() == test_ver
+    ), f"Expected version output in tool stdout to be {test_ver}"

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -2,33 +2,38 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import subprocess
+from pathlib import Path
 
+import pytest
 from _pytest.tmpdir import TempPathFactory
 
-INSTALLER = "./install.sh"
+
+@pytest.fixture(scope="module")
+def installer(build_root: Path) -> Path:
+    return build_root / "install.sh"
 
 
-def test_installer_help():
+def test_installer_help(installer: Path):
     """Validates -h|--help in the installer."""
-    assert "--help" in subprocess.check_output([INSTALLER, "-h"]).decode("utf-8")
-    assert "--help" in subprocess.check_output([INSTALLER, "--help"]).decode("utf-8")
+    assert "--help" in subprocess.check_output([installer, "-h"]).decode("utf-8")
+    assert "--help" in subprocess.check_output([installer, "--help"]).decode("utf-8")
 
 
-def test_installer_fetch_latest(tmp_path_factory: TempPathFactory):
+def test_installer_fetch_latest(tmp_path_factory: TempPathFactory, installer: Path):
     """Invokes install.sh to fetch the latest science release binary, then invokes it."""
     test_dir = tmp_path_factory.mktemp("install-test-default")
     assert "success" in subprocess.check_output(
-        [INSTALLER, "-d", f"{test_dir}/bin"],
+        [installer, "-d", f"{test_dir}/bin"],
         stderr=subprocess.STDOUT,
     ).decode("utf-8")
     assert subprocess.check_output([f"{test_dir}/bin/science", "-V"]).strip()
 
 
-def test_installer_fetch_argtest(tmp_path_factory: TempPathFactory):
+def test_installer_fetch_argtest(tmp_path_factory: TempPathFactory, installer: Path):
     """Exercises all the options in the installer."""
     test_dir = tmp_path_factory.mktemp("install-test")
     output = subprocess.check_output(
-        [INSTALLER, "-V", "0.6.1", "-b", "science061", "-d", f"{test_dir}/bin"],
+        [installer, "-V", "0.6.1", "-b", "science061", "-d", f"{test_dir}/bin"],
         stderr=subprocess.STDOUT,
     ).decode("utf-8")
     assert "success" in output

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -8,6 +8,9 @@ import pytest
 from _pytest.tmpdir import TempPathFactory
 
 from science.os import IS_WINDOWS
+from science.platform import Platform
+
+IS_WINDOWS_X86 = Platform.current() == "windows-x86_64"
 
 
 @pytest.fixture(scope="module")
@@ -27,6 +30,7 @@ def test_installer_help(installer: list):
         assert "--help" in result.stdout, "Expected '--help' in tool output"
 
 
+@pytest.mark.skipif(IS_WINDOWS_X86, reason="no binary releases available for Windows x86_64")
 def test_installer_fetch_latest(tmp_path_factory: TempPathFactory, installer: list):
     """Invokes install.sh to fetch the latest science release binary, then invokes it."""
     test_dir = tmp_path_factory.mktemp("install-test-default")
@@ -39,6 +43,7 @@ def test_installer_fetch_latest(tmp_path_factory: TempPathFactory, installer: li
     assert result.stdout.strip(), "Expected version output in tool stdout"
 
 
+@pytest.mark.skipif(IS_WINDOWS_X86, reason="no binary releases available for Windows x86_64")
 def test_installer_fetch_argtest(tmp_path_factory: TempPathFactory, installer: list):
     """Exercises all the options in the installer."""
     test_dir = tmp_path_factory.mktemp("install-test")

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -8,9 +8,6 @@ import pytest
 from _pytest.tmpdir import TempPathFactory
 
 from science.os import IS_WINDOWS
-from science.platform import Platform
-
-IS_WINDOWS_X86 = Platform.current() == Platform.Windows_x86_64
 
 
 @pytest.fixture(scope="module")
@@ -37,7 +34,6 @@ def test_installer_help(installer: list):
         assert "--help" in result.stdout, "Expected '--help' in tool output"
 
 
-@pytest.mark.skipif(IS_WINDOWS_X86, reason="no binary releases available for Windows x86_64")
 def test_installer_fetch_latest(tmp_path_factory: TempPathFactory, installer: list):
     """Invokes install.sh to fetch the latest science release binary, then invokes it."""
     test_dir = tmp_path_factory.mktemp("install-test-default")
@@ -50,11 +46,10 @@ def test_installer_fetch_latest(tmp_path_factory: TempPathFactory, installer: li
     assert result.stdout.strip(), "Expected version output in tool stdout"
 
 
-@pytest.mark.skipif(IS_WINDOWS_X86, reason="no binary releases available for Windows x86_64")
 def test_installer_fetch_argtest(tmp_path_factory: TempPathFactory, installer: list):
     """Exercises all the options in the installer."""
     test_dir = tmp_path_factory.mktemp("install-test")
-    test_ver = "0.6.1"
+    test_ver = "0.7.0"
     bin_dir = test_dir / "bin"
     bin_file = f"science{test_ver}"
 

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -10,7 +10,7 @@ from _pytest.tmpdir import TempPathFactory
 from science.os import IS_WINDOWS
 from science.platform import Platform
 
-IS_WINDOWS_X86 = Platform.current() == "windows-x86_64"
+IS_WINDOWS_X86 = Platform.current() == Platform.Windows_x86_64
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -13,14 +13,7 @@ from science.os import IS_WINDOWS
 @pytest.fixture(scope="module")
 def installer(build_root: Path) -> list:
     installer = build_root / "install.sh"
-    # Windows has no shebang support, nor a native bash install.
-    if IS_WINDOWS:
-        # If the Windows environment has git installed, git vendors a bash we can reliably use.
-        git_bash = Path(r"C:\Program Files\Git\bin\bash.EXE")
-        # If that doesn't exist, fallback to WSL bash.
-        return [git_bash if git_bash.exists() else "bash.exe", installer]
-    else:
-        return [installer]
+    return [Path(r"C:\Program Files\Git\bin\bash.EXE"), installer] if IS_WINDOWS else [installer]
 
 
 def run_captured(cmd: list):


### PR DESCRIPTION
* Adds a generic `install.sh` utility.
* Updates `README.md` to use the new installer.
* Adds tests.

OSX install example:

```
om:~ kw$ curl -LSsf https://raw.githubusercontent.com/kwlzn/lift/kwlzn/installer/install.sh | /bin/bash
Download URL is: https://github.com/a-scie/lift/releases/latest/download/science-fat-macos-aarch64
######################################################################## 100.0%
######################################################################## 100.0%
Download completed successfully
Download matched it's expected sha256 fingerprint, proceeding
Installed https://github.com/a-scie/lift/releases/latest/download/science-fat-macos-aarch64 to /Users/kw/.local/bin/science
WARNING: /Users/kw/.local/bin is not detected on $PATH
You'll either need to invoke /Users/kw/.local/bin/science explicitly or else add /Users/kw/.local/bin to your shell's PATH.
om:~ kw$ /Users/kw/.local/bin/science -V
0.7.0
```