### PR TITLE
Fixup pytest tmp dir and re-locate nce.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,9 @@ jobs:
       - name: Configure Windows pytest short tmp dir path
         if: matrix.os == 'windows-2022' || matrix.os == 'windows-arm64'
         run: |
-          echo PYTEST_ADDOPTS="--basetemp C:\\tmp\\pytest" >> ${GITHUB_ENV}
+          mkdir -p C:/tmp/gha
+          echo PYTEST_ADDOPTS="--basetemp C:/tmp/gha/pytest" >> ${GITHUB_ENV}
+          echo SCIE_BASE=C:/tmp/gha/nce >> ${GITHUB_ENV}
       - name: Unit Tests
         run: nox -e test -- -vvs
       - name: Build & Package

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -114,11 +114,15 @@ def test_scie_base(tmp_path: Path, science_pyz: Path) -> None:
         )
         assert expected_base == data["scie"]["lift"]["base"]
         expanded_base = os.path.expanduser(expected_base)
+
+        # Ensure our configured scie base is not over-ridden.
+        env = os.environ.copy()
+        env.pop("SCIE_BASE", None)
         try:
             assert (
                 f"Hello from {expanded_base}!"
                 == subprocess.run(
-                    args=[exe_path], stdout=subprocess.PIPE, text=True, check=True
+                    args=[exe_path], env=env, stdout=subprocess.PIPE, text=True, check=True
                 ).stdout.strip()
             )
         finally:


### PR DESCRIPTION
This should avoid Windows long path issues and comports with our self
hosted runner TMP dir setup.