### PR TITLE
Fix release changelog generation.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,7 +92,6 @@ jobs:
           version: ${{ needs.determine-tag.outputs.release-version }}
           setup-python: ${{ matrix.os != 'linux-arm64' && matrix.os != 'windows-arm64' }}
       - name: Create ${{ needs.determine-tag.outputs.release-tag }} Release
-        if: matrix.os == 'ubuntu-22.04'
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ needs.determine-tag.outputs.release-tag }}
@@ -103,10 +102,3 @@ jobs:
           files: dist/science-*
           fail_on_unmatched_files: true
           discussion_category_name: Announcements
-      - name: Add Binaries to ${{ needs.determine-tag.outputs.release-tag }} Release
-        if: matrix.os != 'ubuntu-22.04'
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ needs.determine-tag.outputs.release-tag }}
-          files: dist/science-*
-          fail_on_unmatched_files: true

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,17 +1,17 @@
 # Release Notes
 
-# 0.8.0
+## 0.8.0
 
 Add support for `--no-use-platform-suffix` as a complement to `--use-platform-suffix`. Without
 specifying either, auto-disambiguation is still used to add a platform suffix whenever the
 set of target platforms is not just the current platform, but you can also now force a platform
 suffix to never be used by specifying `--no-use-platform-suffix`.
 
-# 0.7.1
+## 0.7.1
 
 Upgrade the science internal Python distribution to [PBS][PBS] CPython 3.12.6
 
-# 0.7.0
+## 0.7.0
 
 This release adds support for Windows ARM64. 
 


### PR DESCRIPTION
It turns out I started flubbing the headers in 0.7.0 - they should be
level 2.