### PR TITLE
Enable a few skipped tests for s390x & ppc64le.

### DIFF
--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -47,7 +47,7 @@ def test_installer_fetch_latest(tmp_path_factory: TempPathFactory, installer: li
 def test_installer_fetch_argtest(tmp_path_factory: TempPathFactory, installer: list):
     """Exercises all the options in the installer."""
     test_dir = tmp_path_factory.mktemp("install-test")
-    test_ver = "0.9.0"
+    test_ver = "0.10.0"
     bin_dir = test_dir / "bin"
 
     assert (result := run_captured(installer + ["-V", test_ver, "-d", bin_dir])).returncode == 0

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -8,7 +8,6 @@ import pytest
 from _pytest.tmpdir import TempPathFactory
 
 from science.os import IS_WINDOWS
-from science.platform import Platform
 
 
 @pytest.fixture(scope="module")
@@ -31,13 +30,6 @@ def test_installer_help(installer: list):
         assert long_help in result.stdout, f"Expected '{long_help}' in tool output"
 
 
-skip_ppc64le_and_s390x = pytest.mark.skipif(
-    Platform.current() in (Platform.Linux_powerpc64le, Platform.Linux_s390x),
-    reason="Requires a release after 0.9.0 containing ppc64le and s390x support.",
-)
-
-
-@skip_ppc64le_and_s390x
 def test_installer_fetch_latest(tmp_path_factory: TempPathFactory, installer: list):
     """Invokes install.sh to fetch the latest science release binary, then invokes it."""
     test_dir = tmp_path_factory.mktemp("install-test-default")
@@ -52,7 +44,6 @@ def test_installer_fetch_latest(tmp_path_factory: TempPathFactory, installer: li
     assert result.stdout.strip(), "Expected version output in tool stdout"
 
 
-@skip_ppc64le_and_s390x
 def test_installer_fetch_argtest(tmp_path_factory: TempPathFactory, installer: list):
     """Exercises all the options in the installer."""
     test_dir = tmp_path_factory.mktemp("install-test")


### PR DESCRIPTION
Now that the latest (0.10.0) release supports s390x and ppc64le, some
installer tests can be enabled for those platforms.