### PR TITLE
Support mirroring ptex, scie-jump and provided dists.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
           # native deps like psutil) for our shiv.
           UV_PYTHON_VERSION=cpython-3.12.8-windows-x86_64-none
           uv python install ${UV_PYTHON_VERSION}
-          echo UV_PYTHON_ARGS="--python ${UV_PYTHON_VERSION}" >> ${GITHUB_ENV}
+          echo UV_PYTHON="${UV_PYTHON_VERSION}" >> ${GITHUB_ENV}
       - name: Installing emulators
         if: matrix.docker-platform != ''
         run: docker run --privileged --rm tonistiigi/binfmt --install all
@@ -87,7 +87,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Check Formatting & Lints
         if: matrix.docker-platform == ''
-        run: uv run ${UV_PYTHON_ARGS} dev-cmd ci --skip test
+        run: uv run dev-cmd ci --skip test
       - name: Check Formatting & Lints
         if: matrix.docker-platform != ''
         run: |
@@ -112,7 +112,7 @@ jobs:
           echo SCIE_BASE=C:/tmp/gha/nce >> ${GITHUB_ENV}
       - name: Unit Tests
         if: matrix.docker-platform == ''
-        run: uv run ${UV_PYTHON_ARGS} dev-cmd test -- -vvs
+        run: uv run dev-cmd test -- -vvs
       - name: Unit Tests
         if: matrix.docker-platform != ''
         run: |
@@ -142,7 +142,7 @@ jobs:
             python:3.12-bookworm bash _ci_test.sh
       - name: Build & Package
         if: matrix.docker-platform == ''
-        run: uv run ${UV_PYTHON_ARGS} dev-cmd package
+        run: uv run dev-cmd package
       - name: Build & Package
         if: matrix.docker-platform != ''
         run: |
@@ -161,7 +161,7 @@ jobs:
               "
       - name: Generate Doc Site
         if: matrix.docker-platform == ''
-        run: uv run ${UV_PYTHON_ARGS} dev-cmd doc linkcheck
+        run: uv run dev-cmd doc linkcheck
       - name: Generate Doc Site
         if: matrix.docker-platform != ''
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,6 @@
 # The uv venv.
 /.venv/
 
-# Build artifacts dirs.
-/*.egg-info/
-/build/
-
 # Python bytecode.
 __pycache__/
 
@@ -17,5 +13,3 @@ __pycache__/
 # Our Sphinx extension (see: docs/_ext/) dynamically generates doc sources here.
 /docs/_/
 
-# IntelliJ projects.
-.idea/

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 # Release Notes
 
+## 0.11.0
+
+This release brings a new `science download` family of commands for downloading `ptex` binaries,
+`scie-jump` binaries and provider distributions for offline use. To complement this, the
+corresponding lift manifest configuration tables now accept a `base_url` option to point to the
+location of these offline downloads.
+
 ## 0.10.1
 
 This release fixes `science` to retry failed HTTP(S) fetches when appropriate.

--- a/docs/_ext/sphinx_science/directives.py
+++ b/docs/_ext/sphinx_science/directives.py
@@ -64,7 +64,7 @@ class DirectiveSpec:
     content: StringList = field(default_factory=StringList)
 
     def render_markdown(self) -> str:
-        content_items = [f"```{{{self.name}}} {' '.join(self.args)}"]
+        content_items = [f"```{{{self.name}}} {" ".join(self.args)}"]
         for key, val in self.options.items():
             if val is not None:
                 if isinstance(val, bool):

--- a/docs/_ext/sphinx_science/providers.py
+++ b/docs/_ext/sphinx_science/providers.py
@@ -24,10 +24,9 @@ class RenderProviders(MarkdownParser, DocGenDirective):
         )
 
         for provider_info in providers.iter_builtin_providers():
-            slug = provider_info.short_name or provider_info.fully_qualified_name
             yield Doc(
                 id=type_id(provider_info.type),
-                name=slug,
+                name=provider_info.name,
                 directive=dataclasses.replace(
                     directive_spec,
                     args=tuple([provider_info.fully_qualified_name]),

--- a/docs/_ext/sphinx_science/toml.py
+++ b/docs/_ext/sphinx_science/toml.py
@@ -116,7 +116,7 @@ class RawTypenameError(ValueError):
         super().__init__(
             os.linesep.join(
                 (
-                    f"Raw data type names are not allowed and {type_} has no " "configured name.",
+                    f"Raw data type names are not allowed and {type_} has no configured name.",
                     f"Use @{documented_dataclass.__module__}.documented_dataclass(alias=...) "
                     "to define one.",
                 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ dev = [
     "types-beautifulsoup4",
     "types-docutils",
     "types-psutil",
+    "types-setuptools",
     "types-toml",
     "types-tqdm",
 ]
@@ -95,7 +96,7 @@ check-fmt = ["ruff", "format", "--diff"]
 lint = ["ruff", "check", "--fix"]
 check-lint = ["ruff", "check"]
 
-type-check = ["mypy", "docs/_ext", "science", "scripts", "tests", "test-support"]
+type-check = ["mypy", "docs/_ext", "science", "scripts", "setup.py", "tests", "test-support"]
 
 doc = ["sphinx-build", "-b", "html", "-aEW", "docs", "docs/build/html"]
 linkcheck = ["sphinx-build", "-b", "linkcheck", "-aEW", "docs", "docs/build/linkcheck"]

--- a/science/__init__.py
+++ b/science/__init__.py
@@ -3,6 +3,6 @@
 
 from packaging.version import Version
 
-__version__ = "0.10.1"
+__version__ = "0.11.0"
 
 VERSION = Version(__version__)

--- a/science/a_scie.py
+++ b/science/a_scie.py
@@ -11,75 +11,78 @@ from pathlib import Path
 
 from packaging.version import Version
 
-from science.fetcher import fetch_and_verify
+from science.fetcher import FetchResult, fetch_and_verify
 from science.hashing import Digest, Fingerprint
-from science.model import File, Ptex, ScieJump, Url
-from science.platform import Platform
+from science.model import Ptex, ScieJump, Url
+from science.platform import CURRENT_PLATFORM, Platform
 
 
 @dataclass(frozen=True)
-class _LoadResult:
-    path: Path
+class LoadResult(FetchResult):
     binary_name: str
 
 
-def _load_project_release(
+def load_project_release(
     project_name: str,
     binary_name: str,
     version: Version | None = None,
     fingerprint: Digest | Fingerprint | None = None,
-    platform: Platform = Platform.current(),
-) -> _LoadResult:
+    platform: Platform = CURRENT_PLATFORM,
+    base_url: Url | None = None,
+) -> LoadResult:
     qualified_binary_name = platform.qualified_binary_name(binary_name)
-    base_url = f"https://github.com/a-scie/{project_name}/releases"
+    root_url = (base_url or f"https://github.com/a-scie/{project_name}/releases").rstrip("/")
     if version:
         version_path = f"download/v{version}"
         ttl = None
     else:
         version_path = "latest/download"
         ttl = timedelta(days=5)
-    path = fetch_and_verify(
-        url=Url(f"{base_url}/{version_path}/{qualified_binary_name}"),
+    result = fetch_and_verify(
+        url=Url(f"{root_url}/{version_path}/{qualified_binary_name}"),
         fingerprint=fingerprint,
         executable=True,
         ttl=ttl,
     )
-    return _LoadResult(path=path, binary_name=qualified_binary_name)
+    return LoadResult(path=result.path, digest=result.digest, binary_name=qualified_binary_name)
 
 
-def jump(specification: ScieJump | None = None, platform: Platform = Platform.current()) -> Path:
+def jump(
+    specification: ScieJump | None = None, platform: Platform = CURRENT_PLATFORM
+) -> LoadResult:
     version = specification.version if specification else None
     fingerprint = specification.digest if specification and specification.digest else None
-    return _load_project_release(
+    base_url = specification.base_url if specification else None
+    return load_project_release(
         project_name="jump",
         binary_name="scie-jump",
         version=version,
         fingerprint=fingerprint,
         platform=platform,
-    ).path
+        base_url=base_url,
+    )
 
 
-def custom_jump(repo_path: Path) -> Path:
+def custom_jump(repo_path: Path) -> LoadResult:
     dist_dir = tempfile.mkdtemp()
     atexit.register(shutil.rmtree, dist_dir, ignore_errors=True)
     subprocess.run(
         args=["cargo", "run", "-p", "package", "--", dist_dir], cwd=repo_path, check=True
     )
-    return Path(dist_dir) / Platform.current().qualified_binary_name("scie-jump")
+    qualified_binary_name = CURRENT_PLATFORM.qualified_binary_name("scie-jump")
+    path = Path(dist_dir) / qualified_binary_name
+    return LoadResult(path=path, digest=Digest.hash(path), binary_name=qualified_binary_name)
 
 
-def ptex(
-    dest_dir: Path, specification: Ptex | None = None, platform: Platform = Platform.current()
-) -> File:
+def ptex(specification: Ptex | None = None, platform: Platform = CURRENT_PLATFORM) -> LoadResult:
     version = specification.version if specification else None
     fingerprint = specification.digest if specification and specification.digest else None
-    result = _load_project_release(
+    base_url = specification.base_url if specification else None
+    return load_project_release(
         project_name="ptex",
-        fingerprint=fingerprint,
         binary_name="ptex",
         version=version,
+        fingerprint=fingerprint,
         platform=platform,
+        base_url=base_url,
     )
-    (dest_dir / result.binary_name).symlink_to(result.path)
-    ptex_key = specification.id if specification and specification.id else "ptex"
-    return File(name=result.binary_name, key=ptex_key, is_executable=True)

--- a/science/build_info.py
+++ b/science/build_info.py
@@ -18,7 +18,7 @@ from science.dataclass.reflect import metadata
 from science.doc import DOC_SITE_URL
 from science.frozendict import FrozenDict
 from science.hashing import Digest, Provenance
-from science.platform import Platform
+from science.platform import CURRENT_PLATFORM
 
 logger = logging.getLogger(__name__)
 
@@ -63,7 +63,7 @@ class BuildInfo:
             version=__version__,
             url=(
                 f"https://github.com/a-scie/lift/releases/download/v{__version__}/"
-                f"{Platform.current().qualified_binary_name('science')}"
+                f"{CURRENT_PLATFORM.qualified_binary_name("science")}"
             ),
         )
         if self.digest:

--- a/science/cache.py
+++ b/science/cache.py
@@ -4,27 +4,78 @@
 from __future__ import annotations
 
 import atexit
+import errno
 import hashlib
+import os
+import shutil
+import uuid
 from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime, timedelta
+from functools import cached_property
 from pathlib import Path
-from typing import Iterator, TypeAlias
+from typing import ClassVar, Iterator, TypeAlias
 
 from filelock import FileLock
 
 from science.context import ScienceConfig
+from science.model import Url
+
+
+def _delete_dir(directory: Path) -> None:
+    delete_directory = directory.with_suffix(f".{uuid.uuid4().hex}")
+    try:
+        directory.rename(delete_directory)
+    except OSError as e:
+        if e.errno != errno.ENOENT:
+            raise
+    else:
+        shutil.rmtree(delete_directory, ignore_errors=True)
 
 
 @dataclass(frozen=True)
-class Complete:
-    path: Path
+class CacheEntry:
+    _PRIMARY_SUBDIR: ClassVar[str] = "_"
+
+    # N.B.: aux is a reserved word in Windows path names; so we avoid it.
+    # See: https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file#naming-conventions
+    _AUX_SUBDIR: ClassVar[str] = "+"
+
+    _cache_dir: Path
+    _file: str
+
+    @property
+    def path(self) -> Path:
+        return self._cache_dir / self._PRIMARY_SUBDIR / self._file
+
+    @property
+    def aux_dir(self) -> Path:
+        return self._cache_dir / self._AUX_SUBDIR
+
+    def delete(self) -> None:
+        _delete_dir(self._cache_dir)
 
 
 @dataclass(frozen=True)
-class Missing:
-    path: Path
-    work: Path
+class Complete(CacheEntry):
+    pass
+
+
+@dataclass(frozen=True)
+class Missing(CacheEntry):
+    _work_dir: Path
+
+    @cached_property
+    def work_path(self) -> Path:
+        work_dir = self._work_dir / self._PRIMARY_SUBDIR
+        work_dir.mkdir(parents=True, exist_ok=True)
+        return work_dir / self._file
+
+    @cached_property
+    def work_aux_dir(self) -> Path:
+        work_aux_dir = self._work_dir / self._AUX_SUBDIR
+        work_aux_dir.mkdir(parents=True, exist_ok=True)
+        return work_aux_dir
 
 
 CacheResult: TypeAlias = Complete | Missing
@@ -35,46 +86,72 @@ _TTL_EXPIRY_FORMAT = "%m/%d/%y %H:%M:%S"
 
 @dataclass(frozen=True)
 class DownloadCache:
+    # Bump this when changing download cache on-disk structure.
+    _VERSION: ClassVar[int] = 1
+
     base_dir: Path
 
     @contextmanager
-    def get_or_create(self, url: str, ttl: timedelta | None = None) -> Iterator[CacheResult]:
-        """A context manager that yields a `cache result.
+    def get_or_create(self, url: Url, ttl: timedelta | None = None) -> Iterator[CacheResult]:
+        """A context manager that yields a cache result.
 
-        If the cache result is `Missing`, the block yielded to should materialize the given url
-        to the `Missing.work` path. Upon successful exit from this context manager, the given url's
-        content will exist at the cache result path.
+        If the cache result is `Missing`, the block yielded to should materialize the given url to
+        the `Missing.work_path` path. Upon successful exit from this context manager, the given
+        url's content will exist at the cache result path.
+
+        Auxiliary files and directories can be created using `Missing.work_aux_dir` as a base.
+        Anything created under that directory will be made available atomically at the cache result
+        aux dir.
         """
-        cached_file = self.base_dir / hashlib.sha256(url.encode()).hexdigest()
 
-        ttl_file = cached_file.with_suffix(".ttl") if ttl else None
+        # Cache structure looks like so for a cached entry:
+        # ---
+        # <base_dir>/1/abcd1234.lck
+        # <base_dir>/1/abcd1234.ttl
+        # <base_dir>/1/abcd1234/
+        #     _/file
+        #     aux/ (This directory tree is only present if Missing.work_aux_dir is used by caller.)
+        #
+        # For in-flight cache entry creation, you'll find:
+        # ---
+        # <base_dir>/1/abcd1234.lck
+        # <base_dir>/1/abcd1234.work/
+        #     _/file
+        #     aux/ (Again, only present if Missing.work_aux_dir is used by caller.)
+
+        url_hash = hashlib.sha256(url.encode()).hexdigest()
+        cache_dir = self.base_dir / str(self._VERSION) / url_hash
+
+        ttl_file = cache_dir.with_suffix(".ttl") if ttl else None
         if ttl_file and not ttl_file.exists():
-            cached_file.unlink(missing_ok=True)
+            _delete_dir(cache_dir)
         elif ttl_file:
             try:
                 datetime_object = datetime.strptime(
                     ttl_file.read_text().strip(), _TTL_EXPIRY_FORMAT
                 )
                 if datetime.now() > datetime_object:
-                    cached_file.unlink(missing_ok=True)
+                    _delete_dir(cache_dir)
             except ValueError:
-                cached_file.unlink(missing_ok=True)
+                _delete_dir(cache_dir)
 
-        if cached_file.exists():
-            yield Complete(path=cached_file)
+        cache_file = os.path.basename(url.info.path)
+
+        if cache_dir.exists():
+            yield Complete(_cache_dir=cache_dir, _file=cache_file)
             return
 
-        cached_file.parent.mkdir(parents=True, exist_ok=True)
-        with FileLock(str(cached_file.with_name(f"{cached_file.name}.lck"))):
-            if cached_file.exists():
-                yield Complete(path=cached_file)
+        cache_dir.parent.mkdir(parents=True, exist_ok=True)
+        with FileLock(str(cache_dir.with_name(f"{cache_dir.name}.lck"))):
+            if cache_dir.exists():
+                yield Complete(_cache_dir=cache_dir, _file=cache_file)
                 return
 
-            work = cached_file.with_name(f"{cached_file.name}.work")
-            work.unlink(missing_ok=True)
-            atexit.register(work.unlink, missing_ok=True)
-            yield Missing(path=cached_file, work=work)
-            work.rename(cached_file)
+            work_dir = cache_dir.with_name(f"{cache_dir.name}.work")
+            _delete_dir(work_dir)
+            atexit.register(_delete_dir, work_dir)
+            yield Missing(_cache_dir=cache_dir, _file=cache_file, _work_dir=work_dir)
+            work_dir.rename(cache_dir)
             if ttl_file and ttl:
                 ttl_file.write_text((datetime.now() + ttl).strftime(_TTL_EXPIRY_FORMAT))
 

--- a/science/commands/build.py
+++ b/science/commands/build.py
@@ -13,7 +13,7 @@ from science import a_scie
 from science.commands import lift
 from science.commands.lift import LiftConfig, PlatformInfo
 from science.model import Application
-from science.platform import Platform
+from science.platform import CURRENT_PLATFORM, Platform
 
 
 @dataclass(frozen=True)
@@ -38,11 +38,7 @@ def assemble_scies(
     use_jump: Path | None,
     hash_functions: list[str],
 ) -> AssemblyInfo:
-    native_jump_path = (
-        a_scie.custom_jump(repo_path=use_jump)
-        if use_jump
-        else a_scie.jump(platform=platform_info.current)
-    )
+    native_jump_path = (a_scie.custom_jump(repo_path=use_jump) if use_jump else a_scie.jump()).path
 
     scies = list[ScieAssembly]()
     for platform, lift_manifest in lift.export_manifest(
@@ -52,7 +48,7 @@ def assemble_scies(
             a_scie.custom_jump(repo_path=use_jump)
             if use_jump
             else a_scie.jump(specification=application.scie_jump, platform=platform)
-        )
+        ).path
         platform_export_dir = lift_manifest.parent
         subprocess.run(
             args=[str(native_jump_path), "-sj", str(jump_path), lift_manifest],
@@ -61,7 +57,7 @@ def assemble_scies(
             check=True,
         )
 
-        src_binary = platform_export_dir / platform_info.current.binary_name(application.name)
+        src_binary = platform_export_dir / CURRENT_PLATFORM.binary_name(application.name)
         dst_binary_name = platform_info.binary_name(application.name, target_platform=platform)
         dst_binary = platform_export_dir / dst_binary_name
         if src_binary != dst_binary:

--- a/science/commands/doc.py
+++ b/science/commands/doc.py
@@ -21,7 +21,7 @@ import psutil
 
 from science import __version__
 from science.cache import science_cache
-from science.platform import Platform
+from science.platform import CURRENT_PLATFORM
 
 logger = logging.getLogger(__name__)
 
@@ -189,7 +189,7 @@ def launch(
                     | subprocess.CREATE_NEW_PROCESS_GROUP  # type: ignore[attr-defined]
                 )
             }
-            if Platform.current() in (Platform.Windows_aarch64, Platform.Windows_x86_64)
+            if CURRENT_PLATFORM.is_windows
             else {
                 # The os.setsid function is not available on Windows.
                 "preexec_fn": os.setsid  # type: ignore[attr-defined]

--- a/science/commands/download.py
+++ b/science/commands/download.py
@@ -1,0 +1,119 @@
+# Copyright 2025 Science project contributors.
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import itertools
+import logging
+import shutil
+from pathlib import Path
+from typing import Any, Iterable, Iterator, Tuple
+
+import click
+from packaging.version import Version
+
+from science import a_scie
+from science.errors import InputError
+from science.fetcher import fetch_and_verify
+from science.model import Fetch, Identifier
+from science.platform import Platform
+from science.providers import ProviderInfo
+
+logger = logging.getLogger(__name__)
+
+
+def download_a_scie_executables(
+    project_name: str,
+    binary_name: str,
+    versions: Iterable[Version | None],
+    platforms: Iterable[Platform],
+    dest_dir: Path,
+) -> None:
+    for version in versions or [None]:
+        if version:
+            dest = dest_dir / project_name / "download" / f"v{version}"
+        else:
+            dest = dest_dir / project_name / "latest" / "download"
+        dest.mkdir(parents=True, exist_ok=True)
+        for platform in platforms:
+            binary = dest / platform.qualified_binary_name(binary_name)
+            click.echo(
+                f"Downloading {binary_name} {version or "latest"} for {platform} to {binary}...",
+                err=True,
+            )
+            result = a_scie.load_project_release(
+                project_name=project_name,
+                binary_name=binary_name,
+                version=version,
+                platform=platform,
+            )
+            shutil.copy(result.path, binary)
+            binary.with_name(f"{binary.name}.sha256").write_text(
+                f"{result.digest.fingerprint} *{binary.name}"
+            )
+
+
+def download_provider_distribution(
+    provider_info: ProviderInfo,
+    platforms: Iterable[Platform],
+    explicit_platforms: bool,
+    dest_dir: Path,
+    **kwargs: list[Any],
+) -> None:
+    base_dir = dest_dir / "providers" / provider_info.name
+    config_dataclass = provider_info.type.config_dataclass()
+    defaults = {field.name: field.default for field in provider_info.config_fields()}
+
+    def iter_values(name) -> Iterator[Tuple[str, Any]]:
+        values = kwargs[name] or [defaults[name]]
+        for value in values:
+            yield name, value
+
+    configs = [
+        config_dataclass(**dict(params))
+        for params in itertools.product(*(iter_values(name) for name in kwargs))
+    ]
+    for config in configs:
+        provider = provider_info.type.create(Identifier("_"), lazy=False, config=config)
+
+        # TODO(John Sirois): Consider paring down the set of distributions serialized to those we
+        #  actually download. The issue this will introduce is merging partial download distribution
+        #  manifests.
+        distributions = provider.distributions()
+        distributions.serialize(base_dir=base_dir)
+
+        config_desc = " ".join(
+            str(value)
+            for field in provider_info.config_fields()
+            if (value := getattr(config, field.name))
+        )
+        supported_platforms = provider.supported_platforms()
+        for platform in platforms:
+            if platform not in supported_platforms:
+                continue
+            if dist := provider.distribution(platform):
+                assert isinstance(dist.file.source, Fetch), (
+                    f"Expected {provider_info.name} to fetch distributions by URL but {config_desc} for "
+                    f"{platform} has a source of {dist.file.source}."
+                )
+                dest = base_dir / dist.file.source.url.rel_path
+                click.echo(
+                    f"Downloading {provider_info.name} {config_desc} for {platform} to {dest}...",
+                    err=True,
+                )
+                result = fetch_and_verify(
+                    url=dist.file.source.url,
+                    fingerprint=dist.file.digest,
+                    executable=dist.file.is_executable,
+                )
+                dest.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy(result.path, dest)
+                exe_flag = "*" if dist.file.is_executable else " "
+                dest.with_name(f"{dest.name}.sha256").write_text(
+                    f"{result.digest.fingerprint} {exe_flag}{dest.name}"
+                )
+            elif explicit_platforms:
+                raise InputError(f"There is no {provider_info.name} {config_desc} for {platform}.")
+            else:
+                click.secho(
+                    f"There is no {provider_info.name} {config_desc} for {platform}, skipping.",
+                    fg="yellow",
+                )

--- a/science/config.py
+++ b/science/config.py
@@ -153,7 +153,7 @@ def parse_config_data(data: Data) -> Application:
         if len(members) < 2:
             raise InputError(
                 f"At least two interpreter group members are needed to form an interpreter group. "
-                f"Given {f'just {next(iter(members))!r}' if members else 'none'} for interpreter "
+                f"Given {f"just {next(iter(members))!r}" if members else "none"} for interpreter "
                 f"group {fields.id}."
             )
         return InterpreterGroup.create(

--- a/science/data.py
+++ b/science/data.py
@@ -132,7 +132,7 @@ class Data:
             ]
             expected_values = ""
             if issubclass(expected_item_type, Enum):
-                expected_values = f" from {{{', '.join(repr(expected.value) for expected in expected_item_type)}}}"
+                expected_values = f" from {{{", ".join(repr(expected.value) for expected in expected_item_type)}}}"
 
             raise InputError(
                 f"Expected {self.config(key)} defined in {self.provenance.source} to be a list "

--- a/science/options.py
+++ b/science/options.py
@@ -1,0 +1,52 @@
+# Copyright 2022 Science project contributors.
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from dataclasses import dataclass, field
+from typing import Any, Callable
+
+import click
+
+
+def to_option_string(word: str) -> str:
+    return f"--{word.replace("_", "-")}"
+
+
+@dataclass(frozen=True)
+class OptionDescriptor:
+    name: str
+    flag: str = field(default="", kw_only=True)
+
+    def __post_init__(self) -> None:
+        if not self.flag:
+            object.__setattr__(self, "flag", to_option_string(self.name))
+
+
+def mutually_exclusive(
+    option1: str | OptionDescriptor,
+    option2: str | OptionDescriptor,
+    /,
+    *other_options: str | OptionDescriptor,
+) -> Callable[[click.Context, click.Parameter, Any], None]:
+    options = tuple(
+        option if isinstance(option, OptionDescriptor) else OptionDescriptor(option)
+        for option in (option1, option2, *other_options)
+    )
+
+    def check_mutually_exclusive(ctx: click.Context, param: click.Parameter, value: Any) -> Any:
+        if not value:
+            return value
+
+        others = [
+            option.flag
+            for option in options
+            if option.name != param.name and option.name in ctx.params
+        ]
+        if others:
+            head = ", ".join(option.flag for option in options[:-1])
+            tail = options[-1].flag
+            raise click.BadParameter(
+                f"Can only specify one of {head} or {tail}. Already specified {' '.join(others)}."
+            )
+        return value
+
+    return check_mutually_exclusive

--- a/science/platform.py
+++ b/science/platform.py
@@ -23,7 +23,7 @@ class Platform(Enum):
 
     @classmethod
     def parse(cls, value: str) -> Platform:
-        return Platform.current() if "current" == value else Platform(value)
+        return CURRENT_PLATFORM if "current" == value else Platform(value)
 
     @classmethod
     def current(cls) -> Platform:
@@ -59,11 +59,21 @@ class Platform(Enum):
                 )
 
     @property
+    def is_windows(self) -> bool:
+        return self in (self.Windows_aarch64, self.Windows_x86_64)
+
+    @property
     def extension(self):
-        return ".exe" if self in (self.Windows_aarch64, self.Windows_x86_64) else ""
+        return ".exe" if self.is_windows else ""
 
     def binary_name(self, binary_name: str) -> str:
         return f"{binary_name}{self.extension}"
 
     def qualified_binary_name(self, binary_name: str) -> str:
         return f"{binary_name}-{self.value}{self.extension}"
+
+    def __str__(self) -> str:
+        return self.value
+
+
+CURRENT_PLATFORM = Platform.current()

--- a/science/providers/__init__.py
+++ b/science/providers/__init__.py
@@ -34,6 +34,10 @@ class ProviderInfo(Generic[ConfigDataclass]):
         return f"{self.type.__module__}.{self.type.__qualname__}"
 
     @cached_property
+    def name(self) -> str:
+        return self.short_name or self.fully_qualified_name
+
+    @cached_property
     def summary(self) -> str | None:
         if doc := inspect.getdoc(self.type):
             return inspect.cleandoc(doc).splitlines()[0].strip()
@@ -116,3 +120,11 @@ def get_provider(name: str) -> ProviderInfo | None:
         if name in (provider_info.short_name, provider_info.fully_qualified_name):
             return provider_info
     return None
+
+
+def name(provider: Provider) -> str:
+    provider_type = type(provider)
+    for provider_info in ALL_PROVIDERS:
+        if provider_type is provider_info.type:
+            return provider_info.name
+    raise AssertionError(f"Provider of type {provider_type} is not registered!")

--- a/scripts/create-zipapp.py
+++ b/scripts/create-zipapp.py
@@ -1,35 +1,51 @@
 # Copyright 2025 Science project contributors.
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import atexit
+import shutil
 import subprocess
 import sys
 import tempfile
 from pathlib import Path
-from typing import Any
 
 
-def main() -> Any:
-    work_dir = Path(tempfile.mkdtemp())
-    site_packages_dir = work_dir / "site-packages"
+def main() -> int:
+    work_dir = Path(tempfile.mkdtemp(prefix="science-zipapp-build."))
+    atexit.register(shutil.rmtree, work_dir, ignore_errors=True)
+
     locked_requirements = work_dir / "requirements.txt"
+    wheels = work_dir / "wheels"
+    processes = [
+        subprocess.Popen(
+            args=["uv", "-q", "export", "--no-dev", "--no-emit-project", "-o", locked_requirements],
+        ),
+        subprocess.Popen(args=["uv", "-q", "build", "--wheel", "-o", wheels]),
+    ]
+    while processes:
+        process = processes.pop()
+        exit_code = process.wait()
+        if 0 != exit_code:
+            for maybe_in_flight_process in processes:
+                maybe_in_flight_process.terminate()
+            return exit_code
 
-    subprocess.run(
-        args=["uv", "-q", "export", "--no-editable", "--no-dev", "-o", locked_requirements],
-        check=True,
-    )
-    subprocess.run(
-        args=[
-            "uv",
-            "-q",
-            "pip",
-            "install",
-            "--target",
-            site_packages_dir,
-            "--requirements",
-            locked_requirements,
-        ],
-        check=True,
-    )
+    site_packages_dir = work_dir / "site-packages"
+    if 0 != (
+        exit_code := subprocess.call(
+            args=[
+                "uv",
+                "-q",
+                "pip",
+                "install",
+                "--target",
+                site_packages_dir,
+                "--requirements",
+                locked_requirements,
+                *wheels.glob("*.whl"),
+            ]
+        )
+    ):
+        return exit_code
 
     # Science runs in a scie that carries its own interpreter; so pins to a single major/minor for
     # development that matches prod; as such, we can just take the ambient interpreter major/minor
@@ -38,6 +54,7 @@ def main() -> Any:
 
     dest = Path("dist") / "science.pyz"
     dest.parent.mkdir(exist_ok=True)
+    dest.unlink(missing_ok=True)
     return subprocess.call(
         args=[
             "shiv",

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,39 @@
+# Copyright 2025 Science project contributors.
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import atexit
+import shutil
+import tempfile
+from pathlib import Path
+
+from setuptools import setup
+
+_BUILD_DIR: Path | None = None
+
+
+def ensure_unique_build_dir() -> Path:
+    global _BUILD_DIR
+    if _BUILD_DIR is None:
+        _build_dir = Path(tempfile.mkdtemp(prefix="science-dist-build."))
+        atexit.register(shutil.rmtree, _build_dir, ignore_errors=True)
+        _BUILD_DIR = _build_dir
+    return _BUILD_DIR
+
+
+def unique_build_dir(name) -> str:
+    path = ensure_unique_build_dir() / name
+    path.mkdir()
+    return str(path)
+
+
+if __name__ == "__main__":
+    setup(
+        # The `egg_info --egg-base`, `build --build-base` and `bdist_wheel --bdist-dir` setup.py
+        # sub-command options we pass below work around the otherwise default `<CWD>/build/`
+        # directory for all three which defeats concurrency in tests.
+        options={
+            "egg_info": {"egg_base": unique_build_dir("egg_base")},
+            "build": {"build_base": unique_build_dir("build_base")},
+            "bdist_wheel": {"bdist_dir": unique_build_dir("bdist_dir")},
+        }
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,7 @@ from click import Command, Context
 from click.globals import pop_context, push_context
 
 from science.context import ScienceConfig
+from science.platform import CURRENT_PLATFORM, Platform
 
 
 def pytest_sessionstart(session: pytest.Session) -> None:
@@ -41,3 +42,8 @@ def cache_dir(tmp_path: Path) -> Iterator[Path]:
         yield cache_dir
     finally:
         pop_context()
+
+
+@pytest.fixture
+def current_platform() -> Platform:
+    return CURRENT_PLATFORM

--- a/tests/test_a_scie.py
+++ b/tests/test_a_scie.py
@@ -11,17 +11,15 @@ from science.model import Ptex
 
 
 def test_ptex_latest(tmp_path_factory: TempPathFactory) -> None:
-    dest_dir = tmp_path_factory.mktemp("staging")
-    latest = a_scie.ptex(dest_dir=dest_dir)
-    subprocess.run(args=[str(dest_dir / latest.name), "-V"], check=True)
+    latest = a_scie.ptex()
+    subprocess.run(args=[latest.path, "-V"], check=True)
 
 
 def test_ptex_version(tmp_path_factory: TempPathFactory) -> None:
-    dest_dir = tmp_path_factory.mktemp("staging")
-    latest = a_scie.ptex(dest_dir=dest_dir, specification=Ptex(version=version.parse("1.5.0")))
+    latest = a_scie.ptex(specification=Ptex(version=version.parse("1.5.0")))
     assert (
         "1.5.0"
         == subprocess.run(
-            args=[str(dest_dir / latest.name), "-V"], stdout=subprocess.PIPE, text=True, check=True
+            args=[latest.path, "-V"], stdout=subprocess.PIPE, text=True, check=True
         ).stdout.strip()
     )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -12,7 +12,7 @@ from textwrap import dedent
 
 from science.config import parse_config_file
 from science.model import Identifier
-from science.platform import Platform
+from science.platform import CURRENT_PLATFORM
 
 
 def test_parse(build_root: Path) -> None:
@@ -21,7 +21,7 @@ def test_parse(build_root: Path) -> None:
     assert 1 == len(interpreters), "Expected science to ship on a single fixed interpreter."
 
     interpreter = interpreters[0]
-    distribution = interpreter.provider.distribution(Platform.current())
+    distribution = interpreter.provider.distribution(CURRENT_PLATFORM)
     assert (
         distribution is not None
     ), "Expected a Python interpreter distribution to be available for each platform tests run on."
@@ -48,7 +48,7 @@ def test_interpreter_groups(tmp_path: Path, science_pyz: Path) -> None:
             check=True,
         )
 
-        exe_path = tmp_path / Platform.current().binary_name("igs")
+        exe_path = tmp_path / CURRENT_PLATFORM.binary_name("igs")
         subprocess.run(args=[exe_path], env={**os.environ, "SCIE": "inspect"}, check=True)
 
         scie_base = tmp_path / "scie-base"
@@ -79,14 +79,13 @@ def test_interpreter_groups(tmp_path: Path, science_pyz: Path) -> None:
 
 
 def test_scie_base(tmp_path: Path, science_pyz: Path) -> None:
-    current_platform = Platform.current()
-    match current_platform:
-        case Platform.Windows_aarch64 | Platform.Windows_x86_64:
-            config_name = "scie-base.windows.toml"
-            expected_base = "~\\AppData\\Local\\Temp\\custom-base"
-        case _:
-            config_name = "scie-base.unix.toml"
-            expected_base = "/tmp/custom-base"
+    current_platform = CURRENT_PLATFORM
+    if current_platform.is_windows:
+        config_name = "scie-base.windows.toml"
+        expected_base = "~\\AppData\\Local\\Temp\\custom-base"
+    else:
+        config_name = "scie-base.unix.toml"
+        expected_base = "/tmp/custom-base"
 
     with resources.as_file(resources.files("data") / config_name) as config:
         subprocess.run(
@@ -144,7 +143,7 @@ def test_command_descriptions(tmp_path: Path, science_pyz: Path) -> None:
             check=True,
         )
 
-        exe_path = tmp_path / Platform.current().binary_name("command-descriptions")
+        exe_path = tmp_path / CURRENT_PLATFORM.binary_name("command-descriptions")
         scie_base = tmp_path / "scie-base"
         data = json.loads(
             subprocess.run(

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -1,0 +1,247 @@
+# Copyright 2025 Science project contributors.
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from queue import Queue
+from textwrap import dedent
+from threading import Thread
+from typing import Iterator
+
+import pytest
+from pytest import MonkeyPatch
+
+from science.hashing import Digest
+from science.platform import CURRENT_PLATFORM, Platform
+from science.providers import PyPy
+
+
+@pytest.fixture(autouse=True)
+def cache_dir(monkeypatch: MonkeyPatch, tmp_path: Path) -> Path:
+    cache_dir = tmp_path / "cache"
+    monkeypatch.setenv("SCIENCE_CACHE", str(cache_dir))
+    return cache_dir
+
+
+@dataclass(frozen=True)
+class Server:
+    port: int
+    root: Path
+
+    @property
+    def url(self) -> str:
+        return f"http://127.0.0.1:{self.port}"
+
+
+@pytest.fixture
+def server(tmp_path: Path) -> Iterator[Server]:
+    serve_root = tmp_path / "http-root"
+    serve_root.mkdir()
+
+    # N.B.: Running Python in unbuffered mode here is critical to being able to read stdout.
+    process = subprocess.Popen(
+        args=[sys.executable, "-u", "-m", "http.server", "0"],
+        cwd=serve_root,
+        stdout=subprocess.PIPE,
+    )
+    try:
+        port: Queue[int] = Queue()
+
+        def read_data():
+            try:
+                data = process.stdout.readline()
+                match = re.match(rb"^Serving HTTP on \S+ port (?P<port>\d+)\D", data)
+                port.put(int(match.group("port")))
+            finally:
+                port.task_done()
+
+        reader = Thread(target=read_data)
+        reader.daemon = True
+        reader.start()
+        port.join()
+        reader.join()
+
+        yield Server(port=port.get(), root=serve_root)
+    finally:
+        process.kill()
+
+
+def assert_download_mirror(
+    tmp_path: Path, current_platform: Platform, *, download_dir: Path, download_url: str
+) -> None:
+    subprocess.run(args=["science", "download", "ptex", download_dir], check=True)
+    subprocess.run(args=["science", "download", "scie-jump", download_dir], check=True)
+
+    lift_manifest = tmp_path / "lift.toml"
+    scie_jump_qualified_binary_name = current_platform.qualified_binary_name("scie-jump")
+    lift_manifest.write_text(
+        dedent(
+            f"""\
+            [lift]
+            name = "mirror"
+            description = "Test mirroring."
+
+            [lift.ptex]
+            base_url = "{download_url}/ptex/"
+
+            [lift.scie_jump]
+            base_url = "{download_url}/jump"
+
+            [[lift.commands]]
+            exe = "{{ptex}}"
+            args = ["-O", "{download_url}/jump/latest/download/{scie_jump_qualified_binary_name}"]
+            """
+        )
+    )
+    subprocess.run(args=["science", "lift", "build", lift_manifest], cwd=tmp_path, check=True)
+
+    scie = tmp_path / current_platform.binary_name("mirror")
+    split_dir = tmp_path / "split"
+    subprocess.run(args=[scie, split_dir], env={**os.environ, "SCIE": "split"}, check=True)
+    subprocess.run(args=[scie], cwd=tmp_path, check=True)
+
+    assert Digest.hash(tmp_path / scie_jump_qualified_binary_name) == Digest.hash(
+        split_dir / current_platform.binary_name("scie-jump")
+    )
+
+
+def test_download_http_mirror(tmp_path: Path, current_platform: Platform, server: Server) -> None:
+    assert_download_mirror(
+        tmp_path, current_platform, download_dir=server.root, download_url=server.url
+    )
+
+
+def test_download_file_mirror(tmp_path: Path, current_platform: Platform) -> None:
+    download_dir = tmp_path / "download-dir"
+    download_dir_url = (
+        f"file:///{download_dir.as_posix()}"
+        if current_platform.is_windows
+        else f"file://{download_dir}"
+    )
+    assert_download_mirror(
+        tmp_path, current_platform, download_dir=download_dir, download_url=download_dir_url
+    )
+
+
+def test_pbs_mirror(tmp_path: Path, current_platform: Platform) -> None:
+    download_dir = tmp_path / "download-dir"
+    subprocess.run(
+        args=[
+            "science",
+            "download",
+            "provider",
+            "PythonBuildStandalone",
+            "--version",
+            "3.13",
+            "--release",
+            "20250106",
+            "--flavor",
+            "install_only_stripped",
+            download_dir,
+        ],
+        check=True,
+    )
+
+    download_dir_url = (
+        f"file:///{download_dir.as_posix()}"
+        if current_platform.is_windows
+        else f"file://{download_dir}"
+    )
+    lift_manifest = tmp_path / "lift.toml"
+    lift_manifest.write_text(
+        dedent(
+            f"""\
+            [lift]
+            name = "mirror"
+            description = "Test mirroring."
+
+            [[lift.interpreters]]
+            id = "cpython"
+            provider = "PythonBuildStandalone"
+            release = "20250106"
+            version = "3.13"
+            flavor = "install_only_stripped"
+            base_url = "{download_dir_url}/providers/PythonBuildStandalone"
+
+            [[lift.commands]]
+            exe = "#{{cpython:python}}"
+            args = ["-V"]
+            """
+        )
+    )
+    subprocess.run(args=["science", "lift", "build", lift_manifest], cwd=tmp_path, check=True)
+
+    assert (
+        "Python 3.13.1"
+        == subprocess.run(
+            args=[tmp_path / current_platform.binary_name("mirror")],
+            stdout=subprocess.PIPE,
+            text=True,
+            check=True,
+        ).stdout.strip()
+    )
+
+
+@pytest.mark.skipif(
+    CURRENT_PLATFORM not in PyPy.supported_platforms(),
+    reason="PyPy does not have pre-built distributions for the current platform.",
+)
+def test_pypy_mirror(tmp_path: Path, current_platform: Platform) -> None:
+    download_dir = tmp_path / "download-dir"
+    subprocess.run(
+        args=[
+            "science",
+            "download",
+            "provider",
+            "PyPy",
+            "--version",
+            "3.9",
+            "--release",
+            "v7.3.15",
+            download_dir,
+        ],
+        check=True,
+    )
+
+    download_dir_url = (
+        f"file:///{download_dir.as_posix()}"
+        if current_platform.is_windows
+        else f"file://{download_dir}"
+    )
+    lift_manifest = tmp_path / "lift.toml"
+    lift_manifest.write_text(
+        dedent(
+            f"""\
+            [lift]
+            name = "mirror"
+            description = "Test mirroring."
+
+            [[lift.interpreters]]
+            id = "cpython"
+            provider = "PyPy"
+            release = "v7.3.15"
+            version = "3.9"
+            base_url = "{download_dir_url}/providers/PyPy"
+
+            [[lift.commands]]
+            exe = "#{{cpython:python}}"
+            args = ["-V"]
+            """
+        )
+    )
+    subprocess.run(args=["science", "lift", "build", lift_manifest], cwd=tmp_path, check=True)
+
+    assert (
+        subprocess.run(
+            args=[tmp_path / current_platform.binary_name("mirror")],
+            stdout=subprocess.PIPE,
+            text=True,
+            check=True,
+        )
+        .stdout.strip()
+        .startswith("Python 3.9.18 (9c4f8ef178b6, Jan 14 2024, ")
+    )

--- a/tests/test_exe.py
+++ b/tests/test_exe.py
@@ -21,13 +21,13 @@ from typing import Any, Iterable
 
 import pytest
 import toml
-from _pytest.tmpdir import TempPathFactory
+from pytest import TempPathFactory
 from testing import issue
 
 from science import __version__
 from science.config import parse_config_file
 from science.os import IS_WINDOWS
-from science.platform import Platform
+from science.platform import CURRENT_PLATFORM, Platform
 
 
 @pytest.fixture(scope="module")
@@ -61,7 +61,7 @@ def science_exe(
         check=True,
         cwd=build_root,
     )
-    science_exe = dest / Platform.current().binary_name("science")
+    science_exe = dest / CURRENT_PLATFORM.binary_name("science")
     assert science_exe.is_file()
     return science_exe
 
@@ -69,7 +69,7 @@ def science_exe(
 def test_use_platform_suffix(
     tmp_path: Path, science_exe: Path, config: Path, science_pyz: Path, docsite: Path
 ) -> None:
-    expected_executable = tmp_path / Platform.current().qualified_binary_name("science")
+    expected_executable = tmp_path / CURRENT_PLATFORM.qualified_binary_name("science")
     assert not expected_executable.exists()
     subprocess.run(
         args=[
@@ -88,13 +88,13 @@ def test_use_platform_suffix(
         check=True,
     )
     assert expected_executable.is_file()
-    assert not (tmp_path / Platform.current().binary_name("science")).exists()
+    assert not (tmp_path / CURRENT_PLATFORM.binary_name("science")).exists()
 
 
 def test_no_use_platform_suffix(
     tmp_path: Path, science_exe: Path, config: Path, science_pyz: Path, docsite: Path
 ) -> None:
-    current_platform = Platform.current()
+    current_platform = CURRENT_PLATFORM
     foreign_platform = next(plat for plat in Platform if plat is not current_platform)
     expected_executable = tmp_path / foreign_platform.binary_name("science")
     assert not expected_executable.exists()
@@ -142,7 +142,7 @@ def test_hash(
     docsite: Path,
     shasum: str | None,
 ) -> None:
-    expected_executable = tmp_path / Platform.current().binary_name("science")
+    expected_executable = tmp_path / CURRENT_PLATFORM.binary_name("science")
     algorithms = "sha1", "sha256", "sha512"
     expected_checksum_paths = [
         Path(f"{expected_executable}.{algorithm}") for algorithm in algorithms
@@ -376,7 +376,7 @@ def create_url_source_scie(
     )
     lift_toml_content = f"{lift_toml_content}\n{additional_toml}"
 
-    scie = dest / Platform.current().binary_name(expected_name)
+    scie = dest / CURRENT_PLATFORM.binary_name(expected_name)
     result = subprocess.run(
         args=[str(science_exe), "lift", *extra_lift_args, "build", "--dest-dir", str(dest), "-"],
         input=lift_toml_content,
@@ -672,7 +672,7 @@ def test_invert_lazy(tmp_path: Path, science_exe: Path) -> None:
         expected_name="skinny",
     )
     result.assert_success()
-    assert result.scie.name == Platform.current().binary_name("skinny")
+    assert result.scie.name == CURRENT_PLATFORM.binary_name("skinny")
     skinny_scie = result.scie
 
     result = create_url_source_scie(
@@ -683,7 +683,7 @@ def test_invert_lazy(tmp_path: Path, science_exe: Path) -> None:
         expected_name="fat",
     )
     result.assert_success()
-    assert result.scie.name == Platform.current().binary_name("fat")
+    assert result.scie.name == CURRENT_PLATFORM.binary_name("fat")
     fat_scie = result.scie
 
     assert skinny_scie.stat().st_size < fat_scie.stat().st_size
@@ -739,7 +739,7 @@ def test_invert_lazy_non_lazy(tmp_path: Path, science_exe: Path) -> None:
 
 
 def working_pypy_versions() -> list[str]:
-    match Platform.current():
+    match CURRENT_PLATFORM:
         case Platform.Linux_s390x:
             return ["2.7", "3.8", "3.9", "3.10"]
         case Platform.Linux_powerpc64le:
@@ -782,7 +782,7 @@ def test_pypy_provider(tmp_path: Path, science_exe: Path, version: str) -> None:
         check=True,
     )
 
-    scie = dest / Platform.current().binary_name("pypy")
+    scie = dest / CURRENT_PLATFORM.binary_name("pypy")
     assert (
         version
         == subprocess.run(args=[scie], text=True, stdout=subprocess.PIPE, check=True).stdout.strip()

--- a/uv.lock
+++ b/uv.lock
@@ -150,7 +150,7 @@ wheels = [
 
 [[package]]
 name = "dev-cmd"
-version = "0.11.0"
+version = "0.11.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aioconsole" },
@@ -158,9 +158,9 @@ dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9f/75/afc5c7ffdfd032b767e87740b958425ca87bfe1b5c59aa91a531db16fad0/dev_cmd-0.11.0.tar.gz", hash = "sha256:51f7c85be17260d619ac87486300445c2f1e627ecb276d6be31f5ad164948f86", size = 41139 }
+sdist = { url = "https://files.pythonhosted.org/packages/71/05/9fd907b1ad956cd8979faa2e5bd00c4866c03e97b42172702c8f29dc0bc4/dev_cmd-0.11.1.tar.gz", hash = "sha256:4a9d30bb399b7cb6e1948c882ad883d54a6e8b77cb65f0c377220ccf7927ace3", size = 41158 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ae/a3/2ee093e18ecf270c302a0cde5bd66f9143d5f97664d5e650aa820866ff6b/dev_cmd-0.11.0-py3-none-any.whl", hash = "sha256:1d75671e59d04b996039f345cc233eb642326c23e1ad5662f5e889f01366c3e1", size = 27038 },
+    { url = "https://files.pythonhosted.org/packages/70/0f/c4c66db5807a9a1527982eebd4ba62a2f76efcc6fb8b7e9d2c63bc3b4cc2/dev_cmd-0.11.1-py3-none-any.whl", hash = "sha256:395f0ac099e8ec40736b3865602c809082b84bb28c9bd062fd06ba35e7b9954e", size = 27068 },
 ]
 
 [[package]]
@@ -517,7 +517,7 @@ wheels = [
 
 [[package]]
 name = "science"
-version = "0.10.1"
+version = "0.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "appdirs" },
@@ -553,6 +553,7 @@ dev = [
     { name = "types-beautifulsoup4" },
     { name = "types-docutils" },
     { name = "types-psutil" },
+    { name = "types-setuptools" },
     { name = "types-toml" },
     { name = "types-tqdm" },
 ]
@@ -592,6 +593,7 @@ dev = [
     { name = "types-beautifulsoup4" },
     { name = "types-docutils" },
     { name = "types-psutil" },
+    { name = "types-setuptools" },
     { name = "types-toml" },
     { name = "types-tqdm" },
 ]
@@ -834,6 +836,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/fa/3c/4f2a430c01a22abd49a583b6b944173e39e7d01b688190a5618bd59a2e22/types-requests-2.32.0.20241016.tar.gz", hash = "sha256:0d9cad2f27515d0e3e3da7134a1b6f28fb97129d86b867f24d9c726452634d95", size = 18065 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/01/485b3026ff90e5190b5e24f1711522e06c79f4a56c8f4b95848ac072e20f/types_requests-2.32.0.20241016-py3-none-any.whl", hash = "sha256:4195d62d6d3e043a4eaaf08ff8a62184584d2e8684e9d2aa178c7915a7da3747", size = 15836 },
+]
+
+[[package]]
+name = "types-setuptools"
+version = "75.6.0.20241223"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/48/a89068ef20e3bbb559457faf0fd3c18df6df5df73b4b48ebf466974e1f54/types_setuptools-75.6.0.20241223.tar.gz", hash = "sha256:d9478a985057ed48a994c707f548e55aababa85fe1c9b212f43ab5a1fffd3211", size = 48063 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/2f/051d5d23711209d4077d95c62fa8ef6119df7298635e3a929e50376219d1/types_setuptools-75.6.0.20241223-py3-none-any.whl", hash = "sha256:7cbfd3bf2944f88bbcdd321b86ddd878232a277be95d44c78a53585d78ebc2f6", size = 71377 },
 ]
 
 [[package]]


### PR DESCRIPTION
Introduce a `science download` family of commands for mirroring a-scie
binaries and provider distributions to a local directory tree that can
be served up or used directly via `file://` URLs in new `base_url`
configuration options for the corresponding lift manifest entries.

Fixes #113
Fixes #114