### PR TITLE
Fix `ptex` being included in all scies.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## 0.11.2
+
+This release fixes a bug introduced in the 0.11.0 release whereby a `ptex` binary was always
+included in each built scie even when the scie did not use `ptex`. This was functionally harmless
+but did bloat the size of the resulting scie binary by ~5MB.
+
 ## 0.11.1
 
 This release brings two fixes for `science` on Windows:

--- a/science/__init__.py
+++ b/science/__init__.py
@@ -3,6 +3,6 @@
 
 from packaging.version import Version
 
-__version__ = "0.11.1"
+__version__ = "0.11.2"
 
 VERSION = Version(__version__)

--- a/science/dataclass/deserializer.py
+++ b/science/dataclass/deserializer.py
@@ -41,6 +41,8 @@ def _parse_field(
                 ),
             ),
         )
+        if not data_value and default is None:
+            return cast(_F, None)
         return cast(_F, parse(data_value, dataclass_type, custom_parsers=custom_parsers))
 
     if type_.istype(int):

--- a/uv.lock
+++ b/uv.lock
@@ -517,7 +517,7 @@ wheels = [
 
 [[package]]
 name = "science"
-version = "0.11.1"
+version = "0.11.2"
 source = { editable = "." }
 dependencies = [
     { name = "appdirs" },


### PR DESCRIPTION
Only include it when needed.

The over-eager inclusion originated here in the 0.11.0 release:
https://github.com/a-scie/lift/pull/120#discussion_r1913902834