### PR TITLE
Fix `installer.sh` to only require `/bin/sh`.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,6 +145,11 @@ jobs:
       - name: Unit Tests
         if: matrix.image != ''
         run: |
+          if [ "${{ matrix.arch }}" = "ppc64le" ]; then
+            echo "Skipping tests on ppc64le."
+            exit 0
+          fi
+
           "${UV}" run dev-cmd docker -- --image ${{ matrix.image }} --arch ${{ matrix.arch }} \
             test -- -vvs
       - name: Build & Package

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,28 +39,28 @@ jobs:
         include:
           - os: ubuntu-24.04
             name: Linux x86-64 (musl)
-            docker-image: python:3.12-alpine
-            docker-platform: linux/amd64
+            image: alpine
+            arch: amd64
           - os: ubuntu-24.04
             name: Linux x86-64 (glibc)
-            docker-image: python:3.12-bookworm
-            docker-platform: linux/amd64
+            image: debian
+            arch: amd64
           - os: ubuntu-24.04
             name: Linux aarch64
-            docker-image: python:3.12-bookworm
-            docker-platform: linux/arm64
+            image: debian
+            arch: arm64
           - os: ubuntu-24.04
             name: Linux armv7l
-            docker-image: python:3.12-bookworm
-            docker-platform: linux/arm/v7
+            image: debian
+            arch: arm/v7
           - os: ubuntu-24.04
             name: Linux s390x
-            docker-image: python:3.12-bookworm
-            docker-platform: linux/s390x
+            image: debian
+            arch: s390x
           - os: ubuntu-24.04
             name: Linux powerpc64le
-            docker-image: python:3.12-bookworm
-            docker-platform: linux/ppc64le
+            image: debian
+            arch: ppc64le
           - os: macos-13
             name: macOS x86-64
           - os: macos-14
@@ -74,10 +74,10 @@ jobs:
       SCIENCE_AUTH_API_GITHUB_COM_BEARER: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Install the latest version of uv
-        if: matrix.docker-image == '' && matrix.os != 'windows-arm64'
+        if: matrix.os != 'windows-arm64'
         uses: astral-sh/setup-uv@v5
       - name: Setup uv
-        if: matrix.docker-image == '' && matrix.os != 'windows-arm64'
+        if: matrix.os != 'windows-arm64'
         run: |
           export UV="$(which uv)"
           "${UV}" -V
@@ -106,9 +106,6 @@ jobs:
           UV_PYTHON_VERSION=cpython-3.12.9-windows-x86_64-none
           "${UV}" python install ${UV_PYTHON_VERSION}
           echo UV_PYTHON="${UV_PYTHON_VERSION}" >> ${GITHUB_ENV}
-      - name: Installing emulators
-        if: matrix.docker-image != ''
-        run: docker run --privileged --rm tonistiigi/binfmt --install all
       - name: Checkout Lift
         uses: actions/checkout@v4
       - name: Restore MyPy Cache
@@ -121,32 +118,14 @@ jobs:
           key: ${{ matrix.docker-platform || format('{0}-{1}', matrix.os, runner.arch) }}-a-scie-lift-mypy-v1-${{ github.run_id }}
           restore-keys: ${{ matrix.docker-platform || format('{0}-{1}', matrix.os, runner.arch) }}-a-scie-lift-mypy-v1
       - name: Check Formatting & Lints
-        if: matrix.docker-image == ''
+        if: matrix.image == ''
         run: |
           "${UV}" run dev-cmd ci --skip test
       - name: Check Formatting & Lints
-        if: matrix.docker-image != ''
+        if: matrix.image != ''
         run: |
-          cat << EOF > _fmt_lint_check.sh
-          pip install --root-user-action ignore uv
-          addgroup --gid $(id -g) build
-          if [ "${{ matrix.docker-image }}" = "python:3.12-alpine" ]; then
-            adduser -D -g '' -G build -u $(id -u) build
-            apk add gcc git linux-headers musl-dev python3-dev
-          else
-            adduser --disabled-password --gecos '' --gid $(id -g) --uid $(id -u) build
-          fi
-
-          su build -c 'uv run dev-cmd ci --skip test'
-          EOF
-
-          docker run --rm \
-            -e FORCE_COLOR \
-            -e SCIENCE_AUTH_API_GITHUB_COM_BEARER \
-            -v $PWD:/code \
-            -w /code \
-            --platform ${{ matrix.docker-platform }} \
-            ${{ matrix.docker-image }} sh -eu _fmt_lint_check.sh
+          "${UV}" run dev-cmd docker -- --image ${{ matrix.image }} --arch ${{ matrix.arch }} \
+            ci --skip test
       - name: Cache MyPy
         uses: actions/cache/save@v4
         if: github.ref == 'refs/heads/main'
@@ -160,98 +139,32 @@ jobs:
           echo PYTEST_ADDOPTS="--basetemp C:/tmp/gha/pytest" >> ${GITHUB_ENV}
           echo SCIE_BASE=C:/tmp/gha/nce >> ${GITHUB_ENV}
       - name: Unit Tests
-        if: matrix.docker-image == ''
+        if: matrix.image == ''
         run: |
           "${UV}" run dev-cmd test -- -vvs
       - name: Unit Tests
-        if: matrix.docker-image != ''
+        if: matrix.image != ''
         run: |
-          cat << EOF > _test.sh
-          if [ "${{ matrix.docker-platform }}" = "linux/s390x" ]; then
-            # This hack gets the PyPy provider tests working on this image. The old PyPy s390x
-            # distributions dynamically link libffi at an older version than I've been able to
-            # find a multi-platform image with s390x support for.
-            ln -s /usr/lib/s390x-linux-gnu/libffi.so.8 /usr/lib/s390x-linux-gnu/libffi.so.6
-          elif [ "${{ matrix.docker-platform }}" = "linux/ppc64le" ]; then
-            echo "Skipping tests on ppc64le."
-            exit 0
-          fi
-
-          pip install --root-user-action ignore uv
-          addgroup --gid $(id -g) build
-          if [ "${{ matrix.docker-image }}" = "python:3.12-alpine" ]; then
-            adduser -D -g '' -G build -u $(id -u) build
-            # N.B.: The bash and curl packages are additional needs for tests. The rest just
-            # supports building the psutil wheel needed for the science Python distribution.
-            apk add bash curl gcc git linux-headers musl-dev python3-dev
-          else
-            adduser --disabled-password --gecos '' --gid $(id -g) --uid $(id -u) build
-          fi
-
-          su build -c "uv run dev-cmd test -- -vvs"
-          EOF
-
-          docker run --rm \
-            -e FORCE_COLOR \
-            -e SCIENCE_AUTH_API_GITHUB_COM_BEARER \
-            -v $PWD:/code \
-            -w /code \
-            --platform ${{ matrix.docker-platform }} \
-            ${{ matrix.docker-image }} sh -eu _test.sh
+          "${UV}" run dev-cmd docker -- --image ${{ matrix.image }} --arch ${{ matrix.arch }} \
+            test -- -vvs
       - name: Build & Package
-        if: matrix.docker-image == ''
+        if: matrix.image == ''
         run: |
           "${UV}" run dev-cmd package
       - name: Build & Package
-        if: matrix.docker-image != ''
+        if: matrix.image != ''
         run: |
-          cat << EOF > _package.sh
-          pip install --root-user-action ignore uv
-          addgroup --gid $(id -g) build
-          if [ "${{ matrix.docker-image }}" = "python:3.12-alpine" ]; then
-            adduser -D -g '' -G build -u $(id -u) build
-            apk add gcc git linux-headers musl-dev python3-dev
-          else
-            adduser --disabled-password --gecos '' --gid $(id -g) --uid $(id -u) build
-          fi
-
-          su build -c 'uv run dev-cmd package'
-          EOF
-
-          docker run --rm \
-            -e FORCE_COLOR \
-            -e SCIENCE_AUTH_API_GITHUB_COM_BEARER \
-            -v $PWD:/code \
-            -w /code \
-            --platform ${{ matrix.docker-platform }} \
-           ${{ matrix.docker-image }} sh -eu _package.sh
+          "${UV}" run dev-cmd docker -- --image ${{ matrix.image }} --arch ${{ matrix.arch }} \
+            package
       - name: Generate Doc Site
-        if: matrix.docker-image == ''
+        if: matrix.image == ''
         run: |
           "${UV}" run dev-cmd doc linkcheck
       - name: Generate Doc Site
-        if: matrix.docker-image != ''
+        if: matrix.image != ''
         run: |
-          cat << EOF > _doc_linkcheck.sh
-          pip install --root-user-action ignore uv
-          addgroup --gid $(id -g) build
-          if [ "${{ matrix.docker-image }}" = "python:3.12-alpine" ]; then
-            adduser -D -g '' -G build -u $(id -u) build
-            apk add gcc git linux-headers musl-dev python3-dev
-          else
-            adduser --disabled-password --gecos '' --gid $(id -g) --uid $(id -u) build
-          fi
-
-          su build -c 'uv run dev-cmd doc linkcheck'
-          EOF
-
-          docker run --rm \
-            -e FORCE_COLOR \
-            -e SCIENCE_AUTH_API_GITHUB_COM_BEARER \
-            -v $PWD:/code \
-            -w /code \
-            --platform ${{ matrix.docker-platform }} \
-            ${{ matrix.docker-image }} sh -eu _doc_linkcheck.sh
+          "${UV}" run dev-cmd docker -- --image ${{ matrix.image }} --arch ${{ matrix.arch }} \
+            doc linkcheck
       - name: Cleanup
         if: always()
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,28 +56,28 @@ jobs:
         include:
           - os: ubuntu-24.04
             name: Linux x86-64 (musl)
-            docker-image: python:3.12-alpine
-            docker-platform: linux/amd64
+            image: alpine
+            arch: amd64
           - os: ubuntu-24.04
             name: Linux x86-64 (glibc)
-            docker-image: python:3.12-bookworm
-            docker-platform: linux/amd64
+            image: debian
+            arch: amd64
           - os: ubuntu-24.04
             name: Linux aarch64
-            docker-image: python:3.12-bookworm
-            docker-platform: linux/arm64
+            image: debian
+            arch: arm64
           - os: ubuntu-24.04
             name: Linux armv7l
-            docker-image: python:3.12-bookworm
-            docker-platform: linux/arm/v7
+            image: debian
+            arch: arm/v7
           - os: ubuntu-24.04
             name: Linux s390x
-            docker-image: python:3.12-bookworm
-            docker-platform: linux/s390x
+            image: debian
+            arch: s390x
           - os: ubuntu-24.04
             name: Linux powerpc64le
-            docker-image: python:3.12-bookworm
-            docker-platform: linux/ppc64le
+            image: debian
+            arch: ppc64le
           - os: macos-13
             name: macOS x86-64
           - os: macos-14
@@ -97,10 +97,10 @@ jobs:
       discussions: write
     steps:
       - name: Install the latest version of uv
-        if: matrix.docker-image == '' && matrix.os != 'windows-arm64'
+        if: matrix.os != 'windows-arm64'
         uses: astral-sh/setup-uv@v5
       - name: Setup uv
-        if: matrix.docker-image == '' && matrix.os != 'windows-arm64'
+        if: matrix.os != 'windows-arm64'
         run: |
           export UV="$(which uv)"
           "${UV}" -V
@@ -130,39 +130,21 @@ jobs:
           "${UV}" python install ${UV_PYTHON_VERSION}
           echo UV_PYTHON_ARGS="--python ${UV_PYTHON_VERSION}" >> ${GITHUB_ENV}
       - name: Installing emulators
-        if: matrix.docker-image != ''
+        if: matrix.image != ''
         run: docker run --privileged --rm tonistiigi/binfmt --install all
       - name: Checkout lift ${{ needs.determine-tag.outputs.release-tag }}
         uses: actions/checkout@v4
         with:
           ref: ${{ needs.determine-tag.outputs.release-tag }}
       - name: Package science ${{ needs.determine-tag.outputs.release-tag }} binary
-        if: matrix.docker-image == ''
+        if: matrix.image == ''
         run: |
           "${UV}" run ${UV_PYTHON_ARGS} dev-cmd package
       - name: Package science ${{ needs.determine-tag.outputs.release-tag }} binary
-        if: matrix.docker-image != ''
+        if: matrix.image != ''
         run: |
-          cat << EOF > _package.sh
-          pip install --root-user-action ignore uv
-          addgroup --gid $(id -g) build
-          if [ "${{ matrix.docker-image }}" = "python:3.12-alpine" ]; then
-            adduser -D -g '' -G build -u $(id -u) build
-            apk add gcc git linux-headers musl-dev python3-dev
-          else
-            adduser --disabled-password --gecos '' --gid $(id -g) --uid $(id -u) build
-          fi
-
-          su build -c 'uv run dev-cmd package'
-          EOF
-
-          docker run --rm \
-            -e FORCE_COLOR \
-            -e SCIENCE_AUTH_API_GITHUB_COM_BEARER \
-            -v $PWD:/code \
-            -w /code \
-            --platform ${{ matrix.docker-platform }} \
-            ${{ matrix.docker-image }} sh -eu _package.sh
+          "${UV}" run dev-cmd docker -- --image ${{ matrix.image }} --arch ${{ matrix.arch }} \
+            package
       - name: Generate science ${{ needs.determine-tag.outputs.release-tag }} artifact attestations
         uses: actions/attest-build-provenance@v1
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ __pycache__/
 # Our Sphinx extension (see: docs/_ext/) dynamically generates doc sources here.
 /docs/_/
 
+# Various files are copied from the project root to here for building docker images.
+/scripts/docker/ephemeral-build-context/
+

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ like so:
 
 + Linux and macOS:
     ```
-    curl --proto '=https' --tlsv1.2 -LSsf https://raw.githubusercontent.com/a-scie/lift/main/install.sh | bash
+    curl --proto '=https' --tlsv1.2 -LSsf https://raw.githubusercontent.com/a-scie/lift/main/install.sh | sh
     ```
 + Windows PowerShell:
     ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,11 @@ check-lint = ["ruff", "check"]
 
 type-check = ["mypy", "docs/_ext", "science", "scripts", "setup.py", "tests", "test-support"]
 
+[tool.dev-cmd.commands.docker]
+args = ["scripts/docker/uv.py"]
+accepts-extra-args = true
+hidden = true
+
 [tool.dev-cmd.commands.create-zipapp]
 args = ["scripts/create-zipapp.py"]
 hidden = true

--- a/scripts/docker/alpine/Dockerfile
+++ b/scripts/docker/alpine/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.12-alpine
+
+ARG UID
+ARG GID
+
+RUN pip install --root-user-action ignore uv && \
+    addgroup --gid $GID build && \
+    adduser -D -g '' -G build -u $UID build && \
+    apk add \
+        bash \
+        curl \
+        gcc \
+        git \
+        linux-headers \
+        musl-dev \
+        python3-dev

--- a/scripts/docker/debian/Dockerfile
+++ b/scripts/docker/debian/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.12-bookworm
+
+ARG UID
+ARG GID
+
+RUN pip install --root-user-action ignore uv && \
+    addgroup --gid ${GID} build && \
+    adduser --disabled-password --gecos '' --gid ${GID} --uid ${UID} build
+
+COPY post-install.sh /post-install.sh
+RUN /post-install.sh && rm /post-install.sh

--- a/scripts/docker/debian/post-install.sh
+++ b/scripts/docker/debian/post-install.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env sh
+
+set -eu
+
+if [ "$(uname -m)" = "s390x" ]; then
+      # This hack gets the PyPy provider working on this image. The old PyPy s390x distributions
+      # dynamically link libffi at an older version than I've been able to find a multi-platform
+      # image with s390x support for.
+      ln -s /usr/lib/s390x-linux-gnu/libffi.so.8 /usr/lib/s390x-linux-gnu/libffi.so.6
+fi

--- a/scripts/docker/uv.py
+++ b/scripts/docker/uv.py
@@ -9,8 +9,13 @@ from argparse import ArgumentParser
 from pathlib import Path
 from typing import Any
 
+from science.platform import CURRENT_OS, Os
+
 
 def main() -> Any:
+    if CURRENT_OS is Os.Windows:
+        return "This script does not work on Windows yet."
+
     parser = ArgumentParser()
     parser.add_argument("--image", default="debian", choices=["alpine", "debian"])
     parser.add_argument(

--- a/scripts/docker/uv.py
+++ b/scripts/docker/uv.py
@@ -54,15 +54,16 @@ def main() -> Any:
     arch_tag = options.arch.replace("/", "-")
     base_image = f"a-scie/lift/base:{arch_tag}"
 
+    # The type-ignores for os.get{uid,gid} cover Windows which we explicitly fail-fast for above.
     subprocess.run(
         args=[
             "docker",
             "buildx",
             "build",
             "--build-arg",
-            f"UID={os.getuid()}",
+            f"UID={os.getuid()}",  # type:ignore[attr-defined]
             "--build-arg",
-            f"GID={os.getgid()}",
+            f"GID={os.getgid()}",  # type:ignore[attr-defined]
             "--platform",
             platform,
             "--tag",

--- a/scripts/docker/uv.py
+++ b/scripts/docker/uv.py
@@ -46,7 +46,8 @@ def main() -> Any:
     )
 
     parent_dir = Path(__file__).parent
-    base_image = f"a-scie/lift/base:{options.arch}"
+    arch_tag = options.arch.replace("/", "-")
+    base_image = f"a-scie/lift/base:{arch_tag}"
 
     subprocess.run(
         args=[
@@ -66,7 +67,7 @@ def main() -> Any:
         check=True,
     )
 
-    dev_image = f"a-scie/lift/dev:{options.arch}"
+    dev_image = f"a-scie/lift/dev:{arch_tag}"
 
     ephemeral_build_context = parent_dir / "ephemeral-build-context"
     ephemeral_build_context.mkdir(parents=True, exist_ok=True)

--- a/scripts/docker/uv.py
+++ b/scripts/docker/uv.py
@@ -1,0 +1,117 @@
+# Copyright 2025 Science project contributors.
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import os
+import shutil
+import subprocess
+import sys
+from argparse import ArgumentParser
+from pathlib import Path
+from typing import Any
+
+
+def main() -> Any:
+    parser = ArgumentParser()
+    parser.add_argument("--image", default="debian", choices=["alpine", "debian"])
+    parser.add_argument(
+        "--arch",
+        default="amd64",
+        choices=[
+            "amd64",
+            "arm64",
+            "riscv64",
+            "ppc64le",
+            "s390x",
+            "386",
+            "mips64le",
+            "mips64",
+            "arm/v7",
+            "arm/v6",
+        ],
+    )
+    options, args = parser.parse_known_args()
+
+    platform = f"linux/{options.arch}"
+    subprocess.run(
+        args=[
+            "docker",
+            "run",
+            "--privileged",
+            "--rm",
+            "tonistiigi/binfmt",
+            "--install",
+            platform,
+        ],
+        check=True,
+    )
+
+    parent_dir = Path(__file__).parent
+    base_image = f"a-scie/lift/base:{options.arch}"
+
+    subprocess.run(
+        args=[
+            "docker",
+            "buildx",
+            "build",
+            "--build-arg",
+            f"UID={os.getuid()}",
+            "--build-arg",
+            f"GID={os.getgid()}",
+            "--platform",
+            platform,
+            "--tag",
+            base_image,
+            str(parent_dir / options.image),
+        ],
+        check=True,
+    )
+
+    dev_image = f"a-scie/lift/dev:{options.arch}"
+
+    ephemeral_build_context = parent_dir / "ephemeral-build-context"
+    ephemeral_build_context.mkdir(parents=True, exist_ok=True)
+    shutil.copy(Path("pyproject.toml"), ephemeral_build_context)
+    shutil.copy(Path("uv.lock"), ephemeral_build_context)
+
+    subprocess.run(
+        args=[
+            "docker",
+            "buildx",
+            "build",
+            "--build-arg",
+            f"BASE_IMAGE={base_image}",
+            "--build-context",
+            f"ephemeral={ephemeral_build_context}",
+            "--platform",
+            platform,
+            "--tag",
+            dev_image,
+            str(parent_dir / "uv"),
+        ],
+        check=True,
+    )
+
+    subprocess.run(
+        args=[
+            "docker",
+            "run",
+            "-e",
+            "FORCE_COLOR",
+            "-e",
+            "SCIENCE_AUTH_API_GITHUB_COM_BEARER",
+            "-v",
+            f"{Path().absolute()}:/code",
+            "--platform",
+            platform,
+            dev_image,
+            *args,
+        ],
+        check=True,
+    )
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except subprocess.CalledProcessError as e:
+        sys.exit(str(e))

--- a/scripts/docker/uv/Dockerfile
+++ b/scripts/docker/uv/Dockerfile
@@ -1,0 +1,15 @@
+ARG BASE_IMAGE=scratch
+FROM ${BASE_IMAGE}
+
+VOLUME /code
+WORKDIR /code
+
+COPY --from=ephemeral pyproject.toml .
+COPY --from=ephemeral uv.lock .
+RUN chown -R build:build /code
+
+USER build
+ENV UV_LINK_MODE=copy
+RUN uv sync --frozen --no-install-project && rm pyproject.toml uv.lock
+
+ENTRYPOINT ["uv", "run", "dev-cmd"]

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -8,7 +8,6 @@ import pytest
 from _pytest.tmpdir import TempPathFactory
 
 from science.os import IS_WINDOWS
-from science.platform import CURRENT_PLATFORM_SPEC, LibC, Platform, PlatformSpec
 
 
 @pytest.fixture(scope="module")
@@ -31,15 +30,6 @@ def test_installer_help(installer: list):
         assert long_help in result.stdout, f"Expected '{long_help}' in tool output"
 
 
-# TODO(John Sirois): Remove this skip once science is released with 64 bit musl Linux support.
-#  https://github.com/a-scie/lift/issues/139
-skip_64bit_musl_linux = pytest.mark.skipif(
-    CURRENT_PLATFORM_SPEC == PlatformSpec(Platform.Linux_x86_64, LibC.MUSL),
-    reason="No science executable has been released yet for 64 bit musl Linux.",
-)
-
-
-@skip_64bit_musl_linux
 def test_installer_fetch_latest(tmp_path_factory: TempPathFactory, installer: list):
     """Invokes install.sh to fetch the latest science release binary, then invokes it."""
     test_dir = tmp_path_factory.mktemp("install-test-default")
@@ -54,7 +44,6 @@ def test_installer_fetch_latest(tmp_path_factory: TempPathFactory, installer: li
     assert result.stdout.strip(), "Expected version output in tool stdout"
 
 
-@skip_64bit_musl_linux
 def test_installer_fetch_argtest(tmp_path_factory: TempPathFactory, installer: list):
     """Exercises all the options in the installer."""
     test_dir = tmp_path_factory.mktemp("install-test")

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -47,7 +47,7 @@ def test_installer_fetch_latest(tmp_path_factory: TempPathFactory, installer: li
 def test_installer_fetch_argtest(tmp_path_factory: TempPathFactory, installer: list):
     """Exercises all the options in the installer."""
     test_dir = tmp_path_factory.mktemp("install-test")
-    test_ver = "0.10.0"
+    test_ver = "0.12.0"
     bin_dir = test_dir / "bin"
 
     assert (result := run_captured(installer + ["-V", test_ver, "-d", bin_dir])).returncode == 0

--- a/uv.lock
+++ b/uv.lock
@@ -151,7 +151,7 @@ wheels = [
 
 [[package]]
 name = "dev-cmd"
-version = "0.17.0"
+version = "0.17.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aioconsole" },
@@ -160,9 +160,9 @@ dependencies = [
     { name = "packaging" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e2/a3/c2e055d9587cca13c8cf0fc33f0485a86d9862f2b869727119d9b367418a/dev_cmd-0.17.0.tar.gz", hash = "sha256:77c281325d22b6d78b2e16f2e8ddbe8de55f3e8ace55f8aa7130d2999a16b0d6", size = 41951 }
+sdist = { url = "https://files.pythonhosted.org/packages/f4/a6/89ac689277bd87eb76bd9a1b133b8e57c5c5c48bef3d9344dfa01baf6a43/dev_cmd-0.17.1.tar.gz", hash = "sha256:422e5db1fcd0eb9b2025faffff005fab17e861883fbe742cb140a58e7000e4b9", size = 41997 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6b/18/047dc863793bebc9799ff853ed0ff6ed73545a0e3939ceadb1039efe9b0a/dev_cmd-0.17.0-py3-none-any.whl", hash = "sha256:a7f0b8e1e03c017b66074ed0fd3553c13d90241633e28e50abd583f12c7991a4", size = 34916 },
+    { url = "https://files.pythonhosted.org/packages/a2/d3/542b79ffd2fefcb25f84305970a417b070eee47a4d9d0e89eeaa6f906609/dev_cmd-0.17.1-py3-none-any.whl", hash = "sha256:ec44edf4e5f07f9b2bed9d7695b866acb5a1d689214eba397efbdc1db9527b89", size = 34921 },
 ]
 
 [[package]]


### PR DESCRIPTION
This enables use on alpine linux and busybox images.

Fixes #139