### PR TITLE
Support scie name / file name collisions.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## 0.12.1
+
+This release fixes science to support scies where the scie name matches one of the lift file names.
+
 ## 0.12.0
 
 This release adds support for targeting musl libc systems and dogfoods this to ship a `science`

--- a/science/__init__.py
+++ b/science/__init__.py
@@ -3,6 +3,6 @@
 
 from packaging.version import Version
 
-__version__ = "0.12.0"
+__version__ = "0.12.1"
 
 VERSION = Version(__version__)

--- a/science/exe.py
+++ b/science/exe.py
@@ -781,7 +781,7 @@ def export(
 
     application = parse_application(lift_config, config)
     platform_info = PlatformInfo.create(application, use_suffix=use_platform_suffix)
-    with temporary_directory(cleanup=True) as td:
+    with temporary_directory("export") as td:
         for _, manifest_path in lift.export_manifest(
             lift_config, application, dest_dir=td, platform_specs=lift_config.platform_specs
         ):
@@ -789,10 +789,7 @@ def export(
                 manifest_path.relative_to(td) if platform_info.use_suffix else manifest_path.name
             )
             lift_manifest.parent.mkdir(parents=True, exist_ok=True)
-            os.replace(
-                manifest_path,
-                lift_manifest,
-            )
+            shutil.move(manifest_path, lift_manifest)
             click.echo(lift_manifest)
 
 
@@ -898,7 +895,7 @@ def _build(
             f"requires at least 0.9.0."
         )
 
-    with temporary_directory(cleanup=not preserve_sandbox) as td:
+    with temporary_directory("build", delete=not preserve_sandbox) as td:
         assembly_info = build.assemble_scies(
             lift_config=lift_config,
             application=application,

--- a/science/fs.py
+++ b/science/fs.py
@@ -8,11 +8,18 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import Iterator
 
+from science.cache import science_cache
+
+_TMP_BASE_DIR = science_cache() / ".tmp"
+
 
 @contextmanager
-def temporary_directory(cleanup: bool) -> Iterator[Path]:
-    if cleanup:
-        with tempfile.TemporaryDirectory() as td:
-            yield Path(td)
-    else:
-        yield Path(tempfile.mkdtemp())
+def temporary_directory(prefix: str, delete: bool = True) -> Iterator[Path]:
+    _TMP_BASE_DIR.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(
+        dir=_TMP_BASE_DIR,
+        prefix=prefix if prefix.endswith(".") else f"{prefix}.",
+        delete=delete,
+        ignore_cleanup_errors=True,
+    ) as td:
+        yield Path(td)

--- a/tests/test_exe.py
+++ b/tests/test_exe.py
@@ -848,7 +848,7 @@ def test_scie_name_collision_with_file(tmp_path: Path, science_exe: Path) -> Non
         check=True,
     )
 
-    scie = dest / "exe"
+    scie = dest / CURRENT_PLATFORM.binary_name("exe")
     assert os.path.exists(scie)
     assert (
         "3.11.11"


### PR DESCRIPTION
Previously the scie was built in the same directory used to assemble its
files which would lead to an error to write out the scie when its name
matched one of those files.