### PR TITLE
Fix interpreter provider path joining.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Release Notes
 
+## 0.12.4
+
+This release fixes building Unix scies on Windows. Previously, the unix scie would contain
+interpreter provider paths joined using the Windows `\` separator instead of `/`.
+
 ## 0.12.3
 
 Upgrade the science internal Python distribution to [PBS][PBS] CPython 3.12.11.

--- a/science/__init__.py
+++ b/science/__init__.py
@@ -3,6 +3,6 @@
 
 from packaging.version import Version
 
-__version__ = "0.12.3"
+__version__ = "0.12.4"
 
 VERSION = Version(__version__)

--- a/science/commands/lift.py
+++ b/science/commands/lift.py
@@ -283,7 +283,7 @@ def _render_command(
 
     def expand_placeholders(text: str) -> str:
         for distribution in distributions:
-            text = distribution.expand_placeholders(text)
+            text = distribution.expand_placeholders(platform_spec, text)
         for interpreter_group in interpreter_groups:
             text, ig_env = interpreter_group.expand_placeholders(platform_spec, text)
             env.update(ig_env)

--- a/science/platform.py
+++ b/science/platform.py
@@ -66,6 +66,9 @@ class OsArch:
     def extension(self):
         return ".exe" if self.is_windows else ""
 
+    def join_path(self, *components: str) -> str:
+        return ("\\" if self.is_windows else "/").join(components)
+
     def binary_name(self, binary_name: str) -> str:
         return f"{binary_name}{self.extension}"
 
@@ -215,6 +218,9 @@ class PlatformSpec:
     @property
     def is_windows(self) -> bool:
         return self.platform.is_windows
+
+    def join_path(self, *components: str) -> str:
+        return self.platform.join_path(*components)
 
     def __repr__(self) -> str:
         if self.libc:

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,14 +1,14 @@
 # Copyright 2022 Science project contributors.
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-import os.path
 
 from science.frozendict import FrozenDict
 from science.hashing import Digest, Fingerprint
 from science.model import Distribution, Fetch, File, Identifier, Url
+from science.platform import Platform, PlatformSpec
 
 
-def test_distribution() -> None:
+def test_distribution_unix() -> None:
     distribution = Distribution(
         id=Identifier("cpython"),
         file=File(
@@ -36,15 +36,53 @@ def test_distribution() -> None:
         ),
     )
 
-    assert "foo" == distribution.expand_placeholders("foo")
-    assert "#{foo}" == distribution.expand_placeholders("#{foo}")
-    assert "{cpython}" == distribution.expand_placeholders("{cpython}")
+    linux = PlatformSpec(Platform.Linux_x86_64)
+
+    assert "foo" == distribution.expand_placeholders(linux, "foo")
+    assert "#{foo}" == distribution.expand_placeholders(linux, "#{foo}")
+    assert "{cpython}" == distribution.expand_placeholders(linux, "{cpython}")
     assert "{cpython310}/arbitrary/path" == distribution.expand_placeholders(
-        "#{cpython}/arbitrary/path"
+        linux, "#{cpython}/arbitrary/path"
     )
-    assert os.path.join("{cpython310}", "python/bin/python") == distribution.expand_placeholders(
-        "#{cpython:python}"
+    assert "{cpython310}/python/bin/python" == distribution.expand_placeholders(
+        linux, "#{cpython:python}"
     )
-    assert os.path.join("{cpython310}", "python/bin/pip") == distribution.expand_placeholders(
-        "#{cpython:pip}"
+    assert "{cpython310}/python/bin/pip" == distribution.expand_placeholders(
+        linux, "#{cpython:pip}"
+    )
+
+
+def test_distribution_windows() -> None:
+    distribution = Distribution(
+        id=Identifier("cpython"),
+        file=File(
+            name="cpython-3.10.18+20250702-x86_64-pc-windows-msvc-install_only_stripped.tar.gz",
+            key="cpython310",
+            digest=Digest(
+                size=22380849,
+                fingerprint=Fingerprint(
+                    "1d9028a8b16a2dddfd0334a12195eb37653e4ba3dd4691059a58dc18c9c2bad5"
+                ),
+            ),
+            source=Fetch(
+                url=Url(
+                    "https://github.com/astral-sh/python-build-standalone/releases/download/"
+                    "20250702/"
+                    "cpython-3.10.18%2B20250702-x86_64-pc-windows-msvc-install_only_stripped.tar.gz"
+                )
+            ),
+        ),
+        placeholders=FrozenDict({Identifier("python"): "python\\python.exe"}),
+    )
+
+    windows = PlatformSpec(Platform.Windows_x86_64)
+
+    assert "foo" == distribution.expand_placeholders(windows, "foo")
+    assert "#{foo}" == distribution.expand_placeholders(windows, "#{foo}")
+    assert "{cpython}" == distribution.expand_placeholders(windows, "{cpython}")
+    assert "{cpython310}/arbitrary/path" == distribution.expand_placeholders(
+        windows, "#{cpython}/arbitrary/path"
+    )
+    assert r"{cpython310}\python\python.exe" == distribution.expand_placeholders(
+        windows, "#{cpython:python}"
     )


### PR DESCRIPTION
Previously lift manifests for UNIX generated on Windows would use the
`\` separator for joining paths, which was incorrect.

Fixes #156