### PR TITLE
Skip PBS API calls for retired Python versions.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        # N.B.: macos-13 is the oldest non-deprecated Intel Mac runner and macos-14 is the oldest
-        # non-deprecated ARM Mac runner.
+        # N.B.: macos-14 is the oldest non-deprecated ARM Mac runner.
         include:
           - os: ubuntu-24.04
             name: Linux x86-64 (musl)
@@ -58,7 +57,7 @@ jobs:
             name: Linux powerpc64le
             image: debian
             arch: ppc64le
-          - os: macos-13
+          - os: macos-x86_64
             name: macOS x86-64
           - os: macos-14
             name: macOS aarch64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,8 +48,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        # N.B.: macos-13 is the oldest non-deprecated Intel Mac runner and macos-14 is the oldest
-        # non-deprecated ARM Mac runner.
+        # N.B.: macos-14 is the oldest non-deprecated ARM Mac runner.
         include:
           - os: ubuntu-24.04
             name: Linux x86-64 (musl)
@@ -75,7 +74,7 @@ jobs:
             name: Linux powerpc64le
             image: debian
             arch: ppc64le
-          - os: macos-13
+          - os: macos-x86_64
             name: macOS x86-64
           - os: macos-14
             name: macOS aarch64

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Release Notes
 
+## 0.12.5
+
+This release fixes the PythonBuildStandalone provider to avoid making API calls for Python versions
+it knows are not supported.
+
 ## 0.12.4
 
 This release fixes building Unix scies on Windows. Previously, the unix scie would contain

--- a/science/__init__.py
+++ b/science/__init__.py
@@ -3,6 +3,6 @@
 
 from packaging.version import Version
 
-__version__ = "0.12.4"
+__version__ = "0.12.5"
 
 VERSION = Version(__version__)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -225,6 +225,7 @@ def test_platform_specs() -> None:
     CURRENT_PLATFORM is not Platform.Linux_x86_64,
     reason="This test needs to run a Linux x86_64 scie.",
 )
+@pytest.mark.xfail(reason="As of 7/22/2025, https://www.busybox.net is down.")
 def test_PBS_gnu_and_musl(tmp_path: Path, science_pyz: Path) -> None:
     with resources.as_file(resources.files("data") / "PBS-gnu-and-musl.toml") as config:
         subprocess.run(


### PR DESCRIPTION
This is generally good behavior and it should also help with Pex CI
rate limit errors.