### PR TITLE
Fix PBS GitHub API use for latest release.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Release Notes
 
+## 0.12.9
+
+This release fixes the PythonBuildStandalone provider GitHub API usage when probing the latest
+release.
+
 ## 0.12.8
 
 This release fixes the PythonBuildStandalone provider to avoid making API calls for Python versions

--- a/science/__init__.py
+++ b/science/__init__.py
@@ -3,6 +3,6 @@
 
 from packaging.version import Version
 
-__version__ = "0.12.8"
+__version__ = "0.12.9"
 
 VERSION = Version(__version__)

--- a/science/providers/python_build_standalone.py
+++ b/science/providers/python_build_standalone.py
@@ -347,7 +347,7 @@ class PythonBuildStandalone(Provider[Config]):
         # For a given release (optional config parameter), get metadata.
         release_data = fetch_json(release_url, ttl=ttl)
 
-        release = release_data["name"]
+        release = release_data["tag_name"]
         # Names are like:
         #  cpython-3.9.16+20221220-x86_64_v3-unknown-linux-musl-install_only.tar.gz
         name_re = re.compile(


### PR DESCRIPTION
Previously we used the release `name` when we should have been using
`tag_name`.