### PR TITLE
Drop already broken support for `--hash shake_*`.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,13 @@
 # Release Notes
 
+## 0.15.1
+
+This release fixes a bug present since the initial 0.1.0 release for `--hash shake_*`. The SHAKE
+family of hash algorithms requires a length when obtaining a digest unlike all other Python
+guaranteed hash algorithms. Previously, we did not pass a length, leading to failure when building a
+scie; now we just drop support for these hash algorithms instead trusting someone will speak up when
+they have a need for SHAKE.
+
 ## 0.15.0
 
 This release adds support for all `*-full` flavor builds to the [PBS][PBS] provider. Notably, this

--- a/science/__init__.py
+++ b/science/__init__.py
@@ -3,6 +3,6 @@
 
 from packaging.version import Version
 
-__version__ = "0.15.0"
+__version__ = "0.15.1"
 
 VERSION = Version(__version__)

--- a/science/exe.py
+++ b/science/exe.py
@@ -828,7 +828,12 @@ def export(
 @click.option(
     "--hash",
     "hash_functions",
-    type=click.Choice(sorted(hashlib.algorithms_guaranteed)),
+    # N.B.: We skip the shake family of algorithms, when supported, since their digest functions
+    # require a length; i.e.: we cannot just call `.hexdigest()` to get a fingerprint.
+    # See: https://github.com/a-scie/lift/issues/176
+    type=click.Choice(
+        sorted(alg for alg in hashlib.algorithms_guaranteed if not alg.startswith("shake_"))
+    ),
     multiple=True,
     default=[],
     help=dedent(


### PR DESCRIPTION
Fixes #176