### PR TITLE
Accept freethreaded install_only PBS flavors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
             name: Linux powerpc64le
             image: debian/bookworm
             arch: ppc64le
-          - os: macos-x86_64
+          - os: macos-15-intel
             name: macOS x86-64
           - os: macos-14
             name: macOS aarch64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,7 +82,7 @@ jobs:
             name: Linux powerpc64le
             image: debian/bookworm
             arch: ppc64le
-          - os: macos-x86_64
+          - os: macos-15-intel
             name: macOS x86-64
           - os: macos-14
             name: macOS aarch64

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Release Notes
 
+## 0.19.0
+
+This release adds [PBS][PBS] provider support for free-threaded install_only and
+install_only_stripped interpreter distributions.
+
 ## 0.18.1
 
 This release passes the `scie_jump.digest.fingerprint` through to the `scie.jump.hash` lift manifest

--- a/science/__init__.py
+++ b/science/__init__.py
@@ -3,6 +3,6 @@
 
 from packaging.version import Version
 
-__version__ = "0.18.1"
+__version__ = "0.19.0"
 
 VERSION = Version(__version__)

--- a/science/providers/python_build_standalone.py
+++ b/science/providers/python_build_standalone.py
@@ -212,7 +212,7 @@ class Config:
             Currently accepts 'install_only', 'install_only_stripped' and any '-full' flavor.
 
             ```{note}
-            To selected a free-threaded install_only or install_only_stripped build, use the 't'
+            To select a free-threaded install_only or install_only_stripped build, use the 't'
             version suffix.
             ```
 

--- a/science/providers/python_build_standalone.py
+++ b/science/providers/python_build_standalone.py
@@ -209,9 +209,7 @@ class Config:
         metadata=metadata(
             """The flavor of the Python Standalone Builds release to use.
 
-            Currently accepts 'install_only', 'install_only_stripped',
-            'freethreaded-install_only', 'freethreaded-install_only_stripped' and any '-full'
-            flavor.
+            Currently accepts 'install_only', 'install_only_stripped' and any '-full' flavor.
 
             ```{note}
             To selected a free-threaded install_only or install_only_stripped build, use the 't'

--- a/science/providers/python_build_standalone.py
+++ b/science/providers/python_build_standalone.py
@@ -220,7 +220,7 @@ class Config:
 
             ```{caution}
             Older Python Standalone Builds do not provide install_only and install_only_stripped
-            distributions; so you should check
+            distributions for free-threaded builds; so you should check
             [their releases](https://github.com/astral-sh/python-build-standalone/releases) for
             availability.
             ```

--- a/science/providers/python_build_standalone.py
+++ b/science/providers/python_build_standalone.py
@@ -188,7 +188,9 @@ class Config:
         metadata=metadata(
             """The flavor of the Python Standalone Builds release to use.
 
-            Currently accepts 'install_only', 'install_only_stripped' and any '-full' flavor.
+            Currently accepts 'install_only', 'install_only_stripped',
+            'freethreaded-install_only', 'freethreaded-install_only_stripped' and any '-full'
+            flavor.
 
             ```{caution}
             Python Standalone Builds does not provide all variants of '-full' flavors for all Python
@@ -535,7 +537,7 @@ class PythonBuildStandalone(Provider[Config]):
         )
         placeholders = {}
         match self._distributions.flavor:
-            case "install_only" | "install_only_stripped":
+            case flavor if flavor.endswith(("install_only", "install_only_stripped")):
                 if platform_spec.is_windows:
                     placeholders[Identifier("python")] = "python\\python.exe"
                 else:
@@ -552,6 +554,7 @@ class PythonBuildStandalone(Provider[Config]):
             case flavor:
                 raise InputError(
                     "PythonBuildStandalone currently only understands 'install_only', "
-                    f"'install_only_stripped' and '*-full' flavors of distribution; given: {flavor}"
+                    "'install_only_stripped' (optionally 'freethreaded-' prefixed) and '*-full' "
+                    f"flavors of distribution; given: {flavor}"
                 )
         return Distribution(id=self.id, file=file, placeholders=FrozenDict(placeholders))

--- a/science/providers/python_build_standalone.py
+++ b/science/providers/python_build_standalone.py
@@ -4,6 +4,7 @@
 
 import dataclasses
 import json
+import os
 import re
 import urllib.parse
 from dataclasses import dataclass
@@ -67,7 +68,11 @@ class FingerprintedAsset:
 class Distributions:
     @classmethod
     def fetch(
-        cls, base_url: Url, version: Version, flavor: str, release: str | None = None
+        cls,
+        base_url: Url,
+        version: Version,
+        flavor: Flavor,
+        release: str | None = None,
     ) -> Distributions:
         rel_path = (
             PurePath(f"download/{release}" if release else "latest/download")
@@ -89,7 +94,7 @@ class Distributions:
     release: str
     latest: bool
     version: Version
-    flavor: str
+    flavor: Flavor
     assets: tuple[FingerprintedAsset, ...]
 
     def serialize(self, base_dir: Path) -> None:
@@ -131,7 +136,23 @@ class Asset:
         )
 
 
-class _Default(str):
+class Flavor(str):
+    __match_args__ = ("value",)
+
+    def __init__(self, value):
+        self.value = value
+        str.__init__(value)
+
+
+class DefaultFlavor(Flavor):
+    pass
+
+
+class FlavorRe(Flavor):
+    pass
+
+
+class SynthesizedFlavor(Flavor):
     pass
 
 
@@ -183,14 +204,26 @@ class Config:
         default=None,
         metadata=metadata("For Linux x86_64 platforms, the libc to link against."),
     )
-    flavor: str = dataclasses.field(
-        default=_Default("install_only"),
+    flavor: Flavor = dataclasses.field(
+        default=DefaultFlavor("install_only"),
         metadata=metadata(
             """The flavor of the Python Standalone Builds release to use.
 
             Currently accepts 'install_only', 'install_only_stripped',
             'freethreaded-install_only', 'freethreaded-install_only_stripped' and any '-full'
             flavor.
+
+            ```{note}
+            To selected a free-threaded install_only or install_only_stripped build, use the 't'
+            version suffix.
+            ```
+
+            ```{caution}
+            Older Python Standalone Builds do not provide install_only and install_only_stripped
+            distributions; so you should check
+            [their releases](https://github.com/astral-sh/python-build-standalone/releases) for
+            availability.
+            ```
 
             ```{caution}
             Python Standalone Builds does not provide all variants of '-full' flavors for all Python
@@ -219,7 +252,7 @@ class Config:
             suffix: str
             description: str
             version: str
-            flavor: str
+            flavor: Flavor
 
         flavor_request: FlavorRequest | None = None
         if self.version.endswith(("td", "dt")):
@@ -227,25 +260,44 @@ class Config:
                 suffix=self.version[-2:],
                 description="freethreaded debug",
                 version=self.version[:-2],
-                flavor=re.escape("freethreaded+debug-full"),
+                flavor=Flavor("freethreaded+debug-full"),
+            )
+        elif (
+            self.version.endswith("t")
+            and not isinstance(self.flavor, DefaultFlavor)
+            and self.flavor
+            in (
+                Flavor("install_only"),
+                Flavor("install_only_stripped"),
+            )
+        ):
+            flavor_request = FlavorRequest(
+                suffix=self.version[-1:],
+                description="freethreaded",
+                version=self.version[:-1],
+                flavor=SynthesizedFlavor(f"freethreaded-{self.flavor}"),
             )
         elif self.version.endswith("t"):
             flavor_request = FlavorRequest(
                 suffix=self.version[-1:],
                 description="freethreaded",
                 version=self.version[:-1],
-                flavor=r"freethreaded(?:\+(?:pgo|lto)){1,2}-full",
+                flavor=FlavorRe(r"freethreaded(?:\+(?:pgo|lto)){1,2}-full"),
             )
         elif self.version.endswith("d"):
             flavor_request = FlavorRequest(
                 suffix=self.version[-1:],
                 description="debug",
                 version=self.version[:-1],
-                flavor=re.escape("debug-full"),
+                flavor=Flavor("debug-full"),
             )
 
         if flavor_request:
-            if self.flavor and not isinstance(self.flavor, _Default):
+            if (
+                self.flavor
+                and not isinstance(self.flavor, DefaultFlavor)
+                and not isinstance(flavor_request.flavor, SynthesizedFlavor)
+            ):
                 raise InputError(
                     f"The suffix '{flavor_request.suffix}' of version "
                     f"'{flavor_request.version}{flavor_request.suffix}' indicates a "
@@ -256,7 +308,7 @@ class Config:
             object.__setattr__(self, "version", flavor_request.version)
             object.__setattr__(self, "flavor", flavor_request.flavor)
         else:
-            object.__setattr__(self, "flavor", re.escape(self.flavor))
+            object.__setattr__(self, "flavor", self.flavor)
 
 
 @dataclass(frozen=True)
@@ -424,14 +476,15 @@ class PythonBuildStandalone(Provider[Config]):
         release = release_data["tag_name"]
         # Names are like:
         #  cpython-3.9.16+20221220-x86_64_v3-unknown-linux-musl-install_only.tar.gz
+        flavor = config.flavor if isinstance(config.flavor, FlavorRe) else re.escape(config.flavor)
         name_re = re.compile(
             rf"^cpython-(?P<exact_version>{re.escape(str(version))}(?:\.\d+)*((a|b|rc)\d+)?)"
-            rf"\+{re.escape(release)}-(?P<target_triple>.+)-{config.flavor}\.(?P<extension>.+)$"
+            rf"\+{re.escape(release)}-(?P<target_triple>.+)-{flavor}\.(?P<extension>.+)$"
         )
 
         # N.B.: There are 3 types of files in PythonBuildStandalone releases:
         # 1. The release archive.
-        # 2. The release archive .sah256 file with its individual checksum.
+        # 2. The release archive .sha256 file with its individual checksum.
         # 3. The SHA256SUMS file with all the release archive checksums.
         base_url = Url("https://github.com/astral-sh/python-build-standalone/releases")
         sha256sums_url: Url | None = None
@@ -537,7 +590,12 @@ class PythonBuildStandalone(Provider[Config]):
         )
         placeholders = {}
         match self._distributions.flavor:
-            case flavor if flavor.endswith(("install_only", "install_only_stripped")):
+            case (
+                Flavor("install_only")
+                | Flavor("install_only_stripped")
+                | SynthesizedFlavor("freethreaded-install_only")
+                | SynthesizedFlavor("freethreaded-install_only_stripped")
+            ):
                 if platform_spec.is_windows:
                     placeholders[Identifier("python")] = "python\\python.exe"
                 else:
@@ -552,9 +610,13 @@ class PythonBuildStandalone(Provider[Config]):
                     placeholders[Identifier("python")] = f"python/install/bin/python{version}"
                     placeholders[Identifier("pip")] = f"python/install/bin/pip{version}"
             case flavor:
-                raise InputError(
+                error_lines = [
                     "PythonBuildStandalone currently only understands 'install_only', "
-                    "'install_only_stripped' (optionally 'freethreaded-' prefixed) and '*-full' "
-                    f"flavors of distribution; given: {flavor}"
-                )
+                    f"'install_only_stripped' and '*-full' flavors of distribution; given: {flavor}"
+                ]
+                if "freethreaded" in flavor:
+                    error_lines.append(
+                        "To select a free-threaded build, use the 't' version suffix instead."
+                    )
+                raise InputError(os.linesep.join(error_lines))
         return Distribution(id=self.id, file=file, placeholders=FrozenDict(placeholders))

--- a/tests/test_exe.py
+++ b/tests/test_exe.py
@@ -1054,11 +1054,48 @@ def test_pbs_provider_version_suffix(tmp_path: Path, science_exe: Path) -> None:
         "",
         "Tried:",
         (
-            "Provider: The suffix 't' of version '3.14.0t' indicates a freethreaded flavor "
+            "Provider: No released assets found for release 20251120 Python 3.14.0 of flavor "
+            "freethreaded-install_only."
+        ),
+    ]
+    assert (
+        expected_error_message_lines
+        == result.stderr.strip().splitlines()[: len(expected_error_message_lines)]
+    ), result.stderr
+
+    result = subprocess.run(
+        args=[science_exe, "lift", "build", "--dest-dir", str(dest), "-"],
+        input=dedent(
+            """\
+            [lift]
+            name = "exe"
+
+            [[lift.interpreters]]
+            id = "cpython"
+            provider = "PythonBuildStandalone"
+            release = "20251120"
+            version = "3.14.0d"
+            flavor = "install_only"
+
+            [[lift.commands]]
+            exe = "#{cpython:python}"
+            args = ["-VV"]
+            """
+        ),
+        cwd=chroot,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    assert result.returncode != 0
+    expected_error_message_lines = [
+        "Failed to parse `[lift.interpreters[1]] provider`.",
+        "",
+        "Tried:",
+        (
+            "Provider: The suffix 'd' of version '3.14.0d' indicates a debug flavor "
             "CPython build should be selected and cannot be combined with the explicit flavor "
             "'install_only'."
         ),
-        "Either use a version suffix or an explicit flavor, but not both.",
     ]
     assert (
         expected_error_message_lines
@@ -1211,6 +1248,163 @@ def test_pbs_provider_version_suffix(tmp_path: Path, science_exe: Path) -> None:
 
         assert {
             "python_version": "3.14.0",
+            "debug": 1,
+            "free-threaded": 0,
+        } == scie_select("python3.14d")
+
+
+def test_pbs_provider_version_suffix_and_install_only(tmp_path: Path, science_exe: Path) -> None:
+    dest = tmp_path / "dest"
+    chroot = tmp_path / "chroot"
+    chroot.mkdir(parents=True, exist_ok=True)
+
+    exe = tmp_path / "exe"
+    exe.write_text(
+        dedent(
+            """\
+            import json
+            import platform
+            import sys
+            import sysconfig
+
+
+            if __name__ == "__main__":
+                json.dump(
+                    {
+                        "python_version": platform.python_version(),
+                        "debug": sysconfig.get_config_var("Py_DEBUG"),
+                        "free-threaded": sysconfig.get_config_var("Py_GIL_DISABLED"),
+                    },
+                    sys.stdout,
+                )
+            """
+        )
+    )
+
+    manifest = dedent(
+        """\
+        [lift]
+        name = "exe"
+
+        [[lift.files]]
+        name = "exe"
+
+        [[lift.interpreters]]
+        id = "python3.14"
+        provider = "PythonBuildStandalone"
+        release = "20260623"
+        version = "3.14"
+
+        [[lift.interpreters]]
+        id = "python3.14t"
+        provider = "PythonBuildStandalone"
+        release = "20260623"
+        version = "3.14t"
+        flavor = "install_only_stripped"
+
+        [[lift.commands]]
+        exe = "#{cpython:python}"
+        args = ["{exe}"]
+        """
+    )
+
+    # N.B.: PBS does not have debug builds for Windows.
+    if Os.current() == Os.Windows:
+        manifest = dedent(
+            """\
+            {manifest}
+
+            [[lift.interpreter_groups]]
+            id = "cpython"
+            selector = "{{scie.env.PYTHON}}"
+            members = [
+                "python3.14",
+                "python3.14t",
+            ]
+            """
+        ).format(manifest=manifest)
+    else:
+        manifest = dedent(
+            """\
+            {manifest}
+
+            [[lift.interpreters]]
+            id = "python3.14d"
+            provider = "PythonBuildStandalone"
+            release = "20260623"
+            version = "3.14d"
+
+            [[lift.interpreters]]
+            id = "python3.14td"
+            provider = "PythonBuildStandalone"
+            release = "20260623"
+            version = "3.14td"
+
+            [[lift.interpreter_groups]]
+            id = "cpython"
+            selector = "{{scie.env.PYTHON}}"
+            members = [
+                "python3.14",
+                "python3.14t",
+                "python3.14td",
+                "python3.14d",
+            ]
+            """
+        ).format(manifest=manifest)
+
+    subprocess.run(
+        args=[
+            science_exe,
+            "lift",
+            "--file",
+            f"exe={exe}",
+            "build",
+            "--dest-dir",
+            str(dest),
+            "-",
+        ],
+        input=manifest,
+        cwd=chroot,
+        text=True,
+        check=True,
+    )
+
+    scie = dest / CURRENT_PLATFORM.binary_name("exe")
+    assert os.path.exists(scie)
+
+    def scie_select(python) -> dict[str, Any]:
+        return json.loads(
+            subprocess.run(
+                args=[scie],
+                env={**os.environ, "PYTHON": python},
+                stdout=subprocess.PIPE,
+                text=True,
+                check=True,
+            ).stdout
+        )
+
+    assert {
+        "python_version": "3.14.6",
+        "debug": 0,
+        "free-threaded": 0,
+    } == scie_select("python3.14")
+
+    assert {
+        "python_version": "3.14.6",
+        "debug": 0,
+        "free-threaded": 1,
+    } == scie_select("python3.14t")
+
+    # N.B.: PBS does not have debug builds for Windows.
+    if Os.current() is not Os.Windows:
+        assert {
+            "python_version": "3.14.6",
+            "debug": 1,
+            "free-threaded": 1,
+        } == scie_select("python3.14td")
+
+        assert {
+            "python_version": "3.14.6",
             "debug": 1,
             "free-threaded": 0,
         } == scie_select("python3.14d")


### PR DESCRIPTION
Motivated by my efforts to deploy pants on free threaded python.

Stripped flavors of free threaded started being published under [20260508](https://github.com/astral-sh/python-build-standalone/releases#release-20260508).